### PR TITLE
Close mutual poi 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,12 @@ clean: ## Clean all artifacts
 		apps/aecore \
 		apps/aetx \
 		apps/aechannel \
-		apps/aecontract
+		apps/aecontract \
+		apps/aeutils \
+		_build \
+		deps \
+		rebar.lock \
+		rebar.config
 
 $(sparse_path)/: ## Get dependencies from Aeternity Core and build Elixir wrapper apps
 	mkdir -p $@
@@ -49,6 +54,7 @@ $(sparse_path)/: ## Get dependencies from Aeternity Core and build Elixir wrappe
 	echo "aechannel" >> $(sparse_git_path)
 	echo "aechannel" >> $(sparse_git_path)
 	echo "aecontract" >> $(sparse_git_path)
+	echo "aeutils" >> $(sparse_git_path)
 	cd $@ && \
 		git pull origin master && \
 		git checkout $(aecore_git_hash)
@@ -56,7 +62,8 @@ $(sparse_path)/: ## Get dependencies from Aeternity Core and build Elixir wrappe
 		yes | $(mix) new aecore && \
 		yes | $(mix) new aetx && \
 		yes | $(mix) new aechannel && \
-		yes | $(mix) new aecontract
+		yes | $(mix) new aecontract && \
+		yes | $(mix) new aeutils
 
 $(aeminer_path)/: ## Get known version of aeminer
 	git clone https://github.com/aeternity/aeminer.git $@

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Start the code (in iex shell)
 iex(1)> ChannelRunner.start_channel_helper()
 ```
 
-by default the command will start all tests (in parallel) found in the following [array](apps/ae_socket_connector/lib/client_runner.ex#L391), feel free to remove entries to get cleaner log outputs.
+by default the command will start tests one by one found in the following [array](apps/ae_socket_connector/lib/client_runner.ex#L9), feel free to remove entries to get cleaner log outputs.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This implementation benefits by being able calling erlang functions provided by 
 make clean deps
 make shell
 ```
-requires OTP 20.3
 
 ## Configure
 

--- a/apps/ae_socket_connector/lib/channel_runner.ex
+++ b/apps/ae_socket_connector/lib/channel_runner.ex
@@ -4,6 +4,9 @@ defmodule ChannelRunner do
   @ae_url "ws://localhost:3014/channel"
   @network_id "my_test"
 
+  # @ae_url "wss://testnet.demo.aeternity.io/channel"
+  # @network_id "ae_uat"
+
   def start_channel_helper(),
     do: ClientRunner.start_helper(@ae_url, @network_id)
 end

--- a/apps/ae_socket_connector/lib/client_runner.ex
+++ b/apps/ae_socket_connector/lib/client_runner.ex
@@ -8,13 +8,14 @@ defmodule ClientRunner do
 
   def joblist(),
     do: [
-      # &withdraw_after_reconnect/3,
-      # &withdraw_after_reestablish/3,
-      # &backchannel_jobs/3,
-      # &close_solo/3,
-      &close_mutual/3
+      &withdraw_after_reconnect/3,
+      &withdraw_after_reestablish/3,
+      &backchannel_jobs/3,
+      &close_solo/3,
+      &close_mutual/3,
+      # jobs puts, fsm in some state.
       # &reconnect_jobs/3,
-      # &contract_jobs/3,
+      &contract_jobs/3
       # keep this last, this is not returnning as expected
       # &reestablish_jobs/3
     ]
@@ -397,7 +398,6 @@ defmodule ClientRunner do
     jobs_initiator = [
       {:async, fn pid -> SocketConnector.initiate_transfer(pid, 5) end, :empty},
       {:sync, fn pid, from -> SocketConnector.get_poi(pid, from) end, :empty},
-      # {:async, fn pid -> SocketConnector.shutdown(pid) end, :empty},
       close_mutual_job(),
       sequence_finish_job(runner_pid, initiator)
     ]

--- a/apps/ae_socket_connector/lib/client_runner.ex
+++ b/apps/ae_socket_connector/lib/client_runner.ex
@@ -6,9 +6,22 @@ defmodule ClientRunner do
             color: nil,
             job_list: nil
 
+  def joblist(),
+    do: [
+      # &withdraw_after_reconnect/3,
+      # &withdraw_after_reestablish/3,
+      # &backchannel_jobs/3,
+      # &close_solo/3,
+      &close_mutual/3
+      # &reconnect_jobs/3,
+      # &contract_jobs/3,
+      # keep this last, this is not returnning as expected
+      # &reestablish_jobs/3
+    ]
+
   def start_link(
-        {_pub_key, _priv_key, %SocketConnector.WsConnection{}, _ae_url, _network_id, _role, _jobs, _color, _name} =
-          params
+        {_pub_key, _priv_key, %SocketConnector.WsConnection{}, _ae_url, _network_id, _role, _jobs,
+         _color, _name} = params
       ) do
     GenServer.start_link(__MODULE__, params)
   end
@@ -28,9 +41,9 @@ defmodule ClientRunner do
       end,
       channels_update: fn round_initiator, round, method ->
         Logger.debug(
-          "callback received round is: #{inspect(round)} round_initiator is: #{inspect(round_initiator)} method is #{
-            inspect(method)
-          }}",
+          "callback received round is: #{inspect(round)} round_initiator is: #{
+            inspect(round_initiator)
+          } method is #{inspect(method)}}",
           ansi_color: color
         )
 
@@ -54,8 +67,8 @@ defmodule ClientRunner do
 
   # Server
   def init(
-        {pub_key, priv_key, %SocketConnector.WsConnection{} = state_channel_configuration, ae_url, network_id,
-         role, jobs, color, name}
+        {pub_key, priv_key, %SocketConnector.WsConnection{} = state_channel_configuration, ae_url,
+         network_id, role, jobs, color, name}
       ) do
     {:ok, pid_session_holder} =
       SessionHolder.start_link(%{
@@ -126,7 +139,6 @@ defmodule ClientRunner do
               end
 
               Logger.debug("sync response is: #{inspect(response)}", state.color)
-              # Logger.error("sync response is: #{inspect(response)}")
               GenServer.cast(self(), {:process_job_lists})
 
             :local ->
@@ -148,7 +160,7 @@ defmodule ClientRunner do
     end)
   end
 
-  def contract_jobs({_initiator, intiator_account}, {_responder, responder_account}) do
+  def contract_jobs({initiator, intiator_account}, {responder, responder_account}, runner_pid) do
     initiator_contract = {TestAccounts.initiatorPubkeyEncoded(), "contracts/TicTacToe.aes"}
     # responder_contract = {TestAccounts.responderPubkeyEncoded(), "contracts/TicTacToe.aes"}
 
@@ -204,7 +216,8 @@ defmodule ClientRunner do
       assert_funds_job(
         {intiator_account, 6_999_999_499_975},
         {responder_account, 4_000_000_000_015}
-      )
+      ),
+      sequence_finish_job(runner_pid, initiator)
     ]
 
     jobs_responder =
@@ -227,13 +240,14 @@ defmodule ClientRunner do
                'make_move',
                from
              )
-           end, :empty}
+           end, :empty},
+          sequence_finish_job(runner_pid, responder)
         ]
 
     {jobs_initiator, jobs_responder}
   end
 
-  def reestablish_jobs({_initiator, intiator_account}, {_responder, responder_account}) do
+  def reestablish_jobs({initiator, intiator_account}, {responder, responder_account}, runner_pid) do
     jobs_initiator = [
       {:async, fn pid -> SocketConnector.initiate_transfer(pid, 2) end, :empty},
       {:sync,
@@ -241,7 +255,10 @@ defmodule ClientRunner do
          SocketConnector.query_funds(pid, from)
        end, :empty},
       {:async, fn pid -> SocketConnector.leave(pid) end, :empty},
-      {:local, fn _client_runner, pid_session_holder -> SessionHolder.reestablish(pid_session_holder) end, :empty}
+      {:local,
+       fn _client_runner, pid_session_holder -> SessionHolder.reestablish(pid_session_holder) end,
+       :empty},
+      sequence_finish_job(runner_pid, initiator)
     ]
 
     jobs_responder =
@@ -258,13 +275,14 @@ defmodule ClientRunner do
           assert_funds_job(
             {intiator_account, 6_999_999_999_997},
             {responder_account, 4_000_000_000_003}
-          )
+          ),
+          sequence_finish_job(runner_pid, responder)
         ]
 
     {jobs_initiator, jobs_responder}
   end
 
-  def reconnect_jobs({_initiator, intiator_account}, {_responder, responder_account}) do
+  def reconnect_jobs({initiator, intiator_account}, {responder, responder_account}, runner_pid) do
     jobs_initiator = [
       assert_funds_job(
         {intiator_account, 6_999_999_999_999},
@@ -274,7 +292,8 @@ defmodule ClientRunner do
       assert_funds_job(
         {intiator_account, 6_999_999_999_997},
         {responder_account, 4_000_000_000_003}
-      )
+      ),
+      sequence_finish_job(runner_pid, initiator)
     ]
 
     jobs_responder =
@@ -307,25 +326,75 @@ defmodule ClientRunner do
           assert_funds_job(
             {intiator_account, 6_999_999_999_999},
             {responder_account, 4_000_000_000_001}
-          )
+          ),
+          sequence_finish_job(runner_pid, responder)
         ]
 
     {jobs_initiator, jobs_responder}
   end
 
-  def close_solo(_initiator, _responder) do
+  def close_solo_job() do
+    # special cased since this doesn't end up in an update.
+    close_solo = fn pid -> SocketConnector.close_solo(pid) end
+
+    {:local,
+     fn client_runner, pid_session_holder ->
+       SessionHolder.run_action(pid_session_holder, close_solo)
+       GenServer.cast(client_runner, {:process_job_lists})
+     end, :empty}
+  end
+
+  def close_mutual_job() do
+    # special cased since this doesn't end up in an update.
+    shutdown = fn pid -> SocketConnector.shutdown(pid) end
+
+    {:local,
+     fn client_runner, pid_session_holder ->
+       SessionHolder.run_action(pid_session_holder, shutdown)
+       GenServer.cast(client_runner, {:process_job_lists})
+     end, :empty}
+  end
+
+  def close_solo({initiator, _intiator_account}, {responder, _responder_account}, runner_pid) do
     jobs_initiator = [
       {:async, fn pid -> SocketConnector.initiate_transfer(pid, 5) end, :empty},
-      {:async, fn pid -> SocketConnector.close_solo(pid) end, :empty}
+      close_solo_job(),
+      sequence_finish_job(runner_pid, initiator)
     ]
 
-    jobs_responder = []
+    jobs_responder = [
+      sequence_finish_job(runner_pid, responder)
+    ]
 
     {jobs_initiator, jobs_responder}
   end
 
+  def close_mutual({initiator, _intiator_account}, {responder, _responder_account}, runner_pid) do
+    jobs_initiator = [
+      {:async, fn pid -> SocketConnector.initiate_transfer(pid, 5) end, :empty},
+      {:sync, fn pid, from -> SocketConnector.get_poi(pid, from) end, :empty},
+      # {:async, fn pid -> SocketConnector.shutdown(pid) end, :empty},
+      close_mutual_job(),
+      sequence_finish_job(runner_pid, initiator)
+    ]
+
+    jobs_responder = [
+      sequence_finish_job(runner_pid, responder)
+    ]
+
+    {jobs_initiator, jobs_responder}
+  end
+
+  def sequence_finish_job(runner_pid, name) do
+    {:local,
+     fn _client_runner, _pid_session_holder ->
+       Logger.info("Sending termination for #{inspect(name)}")
+       send(runner_pid, {:test_finished, name})
+     end, :empty}
+  end
+
   # https://github.com/aeternity/protocol/blob/master/node/api/channels_api_usage.md#example
-  def backchannel_jobs({initiator, intiator_account}, {_responder, responder_account}) do
+  def backchannel_jobs({initiator, intiator_account}, {responder, responder_account}, runner_pid) do
     jobs_initiator = [
       {:local,
        fn client_runner, pid_session_holder ->
@@ -355,7 +424,8 @@ defmodule ClientRunner do
       assert_funds_job(
         {intiator_account, 6_999_999_999_998},
         {responder_account, 4_000_000_000_002}
-      )
+      ),
+      sequence_finish_job(runner_pid, initiator)
     ]
 
     jobs_responder = [
@@ -381,27 +451,19 @@ defmodule ClientRunner do
         {intiator_account, 7_000_000_000_003},
         {responder_account, 3_999_999_999_997}
       ),
-      {:async, fn pid -> SocketConnector.initiate_transfer(pid, 5) end, :empty}
+      {:async, fn pid -> SocketConnector.initiate_transfer(pid, 5) end, :empty},
+      sequence_finish_job(runner_pid, responder)
     ]
 
     {jobs_initiator, jobs_responder}
   end
 
-  def joblist(),
-    do: [
-      &backchannel_jobs/2,
-      &close_solo/2,
-      &reconnect_jobs/2,
-      &contract_jobs/2,
-      &reestablish_jobs/2
-    ]
-
   def gen_name(name, suffix) do
     String.to_atom(to_string(name) <> Integer.to_string(suffix))
   end
 
-  # to give the FSM a fair chance to pair together the peers. We are using same two accouts for every connection
-  @grace_period_ms 5000
+  # elimiation overlap yields issues, need to be investigated
+  @grace_period_ms 2000
 
   def start_helper(ae_url, network_id) do
     Enum.each(Enum.zip(joblist(), 1..Enum.count(joblist())), fn {fun, suffix} ->
@@ -410,12 +472,31 @@ defmodule ClientRunner do
     end)
   end
 
+  def await_finish([]) do
+    Logger.debug("Scenario reached end")
+  end
+
+  def await_finish(expected_messages) do
+    receive do
+      {:test_finished, name} ->
+        reduced_list = List.delete(expected_messages, name)
+
+        Logger.debug(
+          "Received message from runner: #{inspect(name)} remaining: #{inspect(reduced_list)}"
+        )
+
+        await_finish(reduced_list)
+    end
+  end
+
   def start_helper(ae_url, network_id, name_initator, name_responder, job_builder) do
     initiator_pub = TestAccounts.initiatorPubkeyEncoded()
     responder_pub = TestAccounts.responderPubkeyEncoded()
 
+    Logger.debug("executing test: #{inspect(job_builder)}")
+
     {jobs_initiator, jobs_responder} =
-      job_builder.({name_initator, initiator_pub}, {name_responder, responder_pub})
+      job_builder.({name_initator, initiator_pub}, {name_responder, responder_pub}, self())
 
     state_channel_configuration = %SocketConnector.WsConnection{
       initiator: initiator_pub,
@@ -425,13 +506,17 @@ defmodule ClientRunner do
     }
 
     start_link(
-      {TestAccounts.initiatorPubkeyEncoded(), TestAccounts.initiatorPrivkey(), state_channel_configuration, ae_url,
-       network_id, :initiator, jobs_initiator, :yellow, name_initator}
+      {TestAccounts.initiatorPubkeyEncoded(), TestAccounts.initiatorPrivkey(),
+       state_channel_configuration, ae_url, network_id, :initiator, jobs_initiator, :yellow,
+       name_initator}
     )
 
     start_link(
-      {TestAccounts.responderPubkeyEncoded(), TestAccounts.responderPrivkey(), state_channel_configuration, ae_url,
-       network_id, :responder, jobs_responder, :blue, name_responder}
+      {TestAccounts.responderPubkeyEncoded(), TestAccounts.responderPrivkey(),
+       state_channel_configuration, ae_url, network_id, :responder, jobs_responder, :blue,
+       name_responder}
     )
+
+    await_finish([name_initator, name_responder])
   end
 end

--- a/apps/ae_socket_connector/lib/client_runner.ex
+++ b/apps/ae_socket_connector/lib/client_runner.ex
@@ -15,6 +15,7 @@ defmodule ClientRunner do
 
   def connection_callback(callback_pid, color) do
     %SocketConnector.ConnectionCallbacks{
+      # auto approval is the suggested response. Typically if initiated by us and matches with our request we should approve.
       sign_approve: fn round_initiator, round, auto_approval, human ->
         Logger.debug(
           "Sign request for round: #{inspect(round)}, initated by: #{inspect(round_initiator)}. auto_approval: #{

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -6,8 +6,7 @@ defmodule SessionHolder do
 
   defstruct pid: nil,
             color: nil,
-            configuration: %SocketConnector{},
-            ae_url: ""
+            configuration: %SocketConnector{}
 
   def start_link(%{
         socket_connector: %SocketConnector{} = configuration,
@@ -33,6 +32,10 @@ defmodule SessionHolder do
 
   def reconnect(pid) do
     GenServer.cast(pid, {:reconnect})
+  end
+
+  def stop_helper(pid) do
+    run_action(pid, fn pid -> SocketConnector.leave(pid) end)
   end
 
   def run_action(pid, action) do
@@ -84,7 +87,13 @@ defmodule SessionHolder do
     Logger.debug("about to re-establish connection", ansi_color: state.color)
 
     {:ok, pid} =
-      SocketConnector.start_link(:alice, state.configuration, :reestablish, state.color, self())
+      SocketConnector.start_link(
+        :alice,
+        :reestablish,
+        state.configuration,
+        state.color,
+        self()
+      )
 
     {:noreply, %__MODULE__{state | pid: pid}}
   end

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -102,9 +102,7 @@ defmodule SessionHolder do
   # TODO this allows backchannel signing, either way. Should we should uppdate round in the state?
   def handle_call({:sign_request, to_sign}, _from, state) do
     sign_result =
-      Signer.sign_transaction(to_sign, nil, state.configuration, fn _tx,
-                                                                            _round_initiator,
-                                                                            _state ->
+      Signer.sign_transaction(to_sign, state.configuration, fn _tx, _round_initiator, _state ->
         :ok
       end)
 

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -102,7 +102,7 @@ defmodule SessionHolder do
   # TODO this allows backchannel signing, either way. Should we should uppdate round in the state?
   def handle_call({:sign_request, to_sign}, _from, state) do
     sign_result =
-      Signer.sign_transaction_perform(to_sign, nil, state.configuration, fn _tx,
+      Signer.sign_transaction(to_sign, nil, state.configuration, fn _tx,
                                                                             _round_initiator,
                                                                             _state ->
         :ok

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -49,7 +49,8 @@ defmodule SessionHolder do
 
   # Server
   def init({%SocketConnector{} = configuration, ae_url, network_id, color}) do
-    {:ok, pid} = SocketConnector.start_link(:alice, configuration, ae_url, network_id, color, self())
+    {:ok, pid} =
+      SocketConnector.start_link(:alice, configuration, ae_url, network_id, color, self())
 
     {:ok, %__MODULE__{pid: pid, configuration: configuration, color: color}}
   end
@@ -73,7 +74,8 @@ defmodule SessionHolder do
   def handle_cast({:reconnect}, state) do
     Logger.debug("about to re-connect connection", ansi_color: state.color)
 
-    {:ok, pid} = SocketConnector.start_link(:alice, state.configuration, :reconnect, state.color, self())
+    {:ok, pid} =
+      SocketConnector.start_link(:alice, state.configuration, :reconnect, state.color, self())
 
     {:noreply, %__MODULE__{state | pid: pid}}
   end
@@ -81,7 +83,8 @@ defmodule SessionHolder do
   def handle_cast({:reestablish}, state) do
     Logger.debug("about to re-establish connection", ansi_color: state.color)
 
-    {:ok, pid} = SocketConnector.start_link(:alice, state.configuration, :reestablish, state.color, self())
+    {:ok, pid} =
+      SocketConnector.start_link(:alice, state.configuration, :reestablish, state.color, self())
 
     {:noreply, %__MODULE__{state | pid: pid}}
   end
@@ -99,7 +102,11 @@ defmodule SessionHolder do
   # TODO this allows backchannel signing, either way. Should we should uppdate round in the state?
   def handle_call({:sign_request, to_sign}, _from, state) do
     sign_result =
-      Signer.sign_transaction_perform(to_sign, state.configuration, fn _tx, _round_initiator, _state -> :ok end)
+      Signer.sign_transaction_perform(to_sign, nil, state.configuration, fn _tx,
+                                                                            _round_initiator,
+                                                                            _state ->
+        :ok
+      end)
 
     {:reply, sign_result, state}
   end

--- a/apps/ae_socket_connector/lib/signer.ex
+++ b/apps/ae_socket_connector/lib/signer.ex
@@ -3,23 +3,6 @@ defmodule Signer do
   require Logger
   alias SocketConnector.Update
 
-  def sign_transaction(update, authenticator, state, method: method, logstring: _logstring) do
-    enc_signed_create_tx = sign_transaction_perform(update, nil, state, authenticator)
-    generate_transaction_response(enc_signed_create_tx, method: method)
-  end
-
-  def sign_transaction(update, poi, authenticator, state, method: method, logstring: _logstring) do
-    enc_signed_create_tx = sign_transaction_perform(update, poi, state, authenticator)
-    generate_transaction_response(enc_signed_create_tx, method: method)
-  end
-
-  # this should be merged with SockerConnector.build_request no rpc stuff here.
-  def generate_transaction_response(signed_payload, method: method) do
-    response = %{jsonrpc: "2.0", method: method, params: %{signed_tx: signed_payload}}
-    response
-  end
-
-  # TODO harmonize this with the other sign code in this file.
   def sign_aetx(aetx, state) do
     bin = :aetx.serialize_to_binary(aetx)
     bin_for_network = <<state.network_id::binary, bin::binary>>
@@ -32,7 +15,7 @@ defmodule Signer do
     )
   end
 
-  def sign_transaction_perform(
+  def sign_transaction(
         to_sign,
         poi,
         state,
@@ -40,7 +23,7 @@ defmodule Signer do
       )
 
   # https://github.com/aeternity/aeternity/commit/e164fc4518263db9692c02a9b84e179d69bfcc13#diff-e14138de459cdd890333dfad3bd83f4c
-  def sign_transaction_perform(
+  def sign_transaction(
         %Update{} = pending_update,
         poi_encoded,
         state,
@@ -95,13 +78,13 @@ defmodule Signer do
     end
   end
 
-  def sign_transaction_perform(
+  def sign_transaction(
         to_sign,
         poi,
         state,
         verify_hook
       ) do
-    sign_transaction_perform(
+    sign_transaction(
       %Update{tx: to_sign, round_initiator: :not_implemented},
       poi,
       state,

--- a/apps/ae_socket_connector/lib/signer.ex
+++ b/apps/ae_socket_connector/lib/signer.ex
@@ -66,39 +66,4 @@ defmodule Signer do
       verify_hook
     )
   end
-
-  def extract_poi_hash(poi_encoded, accounts, _contracts) do
-    # -spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> amount().
-    # we could alos consider aesc_utils:accounts_in_poi(Peers, PoI)
-    {:ok, poi_binary} = :aeser_api_encoder.safe_decode(:poi, poi_encoded)
-    poi = :aec_trees.deserialize_poi(poi_binary)
-
-    # [account | _r] =  accounts
-    # {:account_pubkey, puk_key_binary} = :aeser_api_encoder.decode(account)
-    # {:ok, account} = :aec_trees.lookup_poi(:accounts, puk_key_binary, poi)
-    #
-    # Logger.debug("Accounts is#{inspect(account)}")
-    # balance = :aec_accounts.balance(account)
-    # Logger.debug("balance is #{inspect(balance)}")
-    # aeu_mp_trees
-
-    poi_hash = :aec_trees.poi_hash(poi)
-    Logger.debug("poi hash is #{inspect(poi_hash)}")
-
-    # alternative
-    {:ok, accounts_in_poi} =
-      :aesc_utils.accounts_in_poi(
-        Enum.map(accounts, fn account ->
-          {:account_pubkey, puk_key_binary} = :aeser_api_encoder.decode(account)
-          puk_key_binary
-        end),
-        poi
-      )
-
-    Logger.debug("Accounts in poi are: #{inspect(accounts_in_poi)}")
-
-    Enum.map(accounts_in_poi, fn account ->
-      Logger.debug("Balance is #{inspect(:aec_accounts.balance(account))}")
-    end)
-  end
 end

--- a/apps/ae_socket_connector/lib/signer.ex
+++ b/apps/ae_socket_connector/lib/signer.ex
@@ -18,7 +18,6 @@ defmodule Signer do
 
   def sign_transaction(
         to_sign,
-        poi,
         state,
         verify_hook \\ fn _tx, _round_initiator, _state -> :unsecure end
       )
@@ -26,34 +25,10 @@ defmodule Signer do
   # https://github.com/aeternity/aeternity/commit/e164fc4518263db9692c02a9b84e179d69bfcc13#diff-e14138de459cdd890333dfad3bd83f4c
   def sign_transaction(
         %Update{} = pending_update,
-        poi_encoded,
         state,
         verify_hook
       ) do
     %Update{tx: to_sign, round_initiator: round_initiator} = pending_update
-
-    case poi_encoded do
-      nil ->
-        :ok
-
-      _ ->
-        # -spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> amount().
-        # we could alos consider aesc_utils:accounts_in_poi(Peers, PoI)
-        {:ok, poi_binary} = :aeser_api_encoder.safe_decode(:poi, poi_encoded)
-        poi = :aec_trees.deserialize_poi(poi_binary)
-
-        {:account_pubkey, puk_key_binary} = :aeser_api_encoder.decode(state.session.initiator)
-        {:ok, account} = :aec_trees.lookup_poi(:accounts, puk_key_binary, poi)
-
-        Logger.debug("Accounts is#{inspect(account)}")
-        balance = :aec_accounts.balance(account)
-        Logger.debug("balance is #{inspect(balance)}")
-
-        poi_hash = :aec_trees.poi_hash(poi)
-        Logger.debug("poi hash is #{inspect(poi_hash)}")
-
-        # aeu_mp_trees
-    end
 
     {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, to_sign)
     # returns #aetx
@@ -82,15 +57,48 @@ defmodule Signer do
 
   def sign_transaction(
         to_sign,
-        poi,
         state,
         verify_hook
       ) do
     sign_transaction(
       %Update{tx: to_sign, round_initiator: :not_implemented},
-      poi,
       state,
       verify_hook
     )
+  end
+
+  def extract_poi_hash(poi_encoded, accounts, _contracts) do
+    # -spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> amount().
+    # we could alos consider aesc_utils:accounts_in_poi(Peers, PoI)
+    {:ok, poi_binary} = :aeser_api_encoder.safe_decode(:poi, poi_encoded)
+    poi = :aec_trees.deserialize_poi(poi_binary)
+
+    # [account | _r] =  accounts
+    # {:account_pubkey, puk_key_binary} = :aeser_api_encoder.decode(account)
+    # {:ok, account} = :aec_trees.lookup_poi(:accounts, puk_key_binary, poi)
+    #
+    # Logger.debug("Accounts is#{inspect(account)}")
+    # balance = :aec_accounts.balance(account)
+    # Logger.debug("balance is #{inspect(balance)}")
+    # aeu_mp_trees
+
+    poi_hash = :aec_trees.poi_hash(poi)
+    Logger.debug("poi hash is #{inspect(poi_hash)}")
+
+    # alternative
+    {:ok, accounts_in_poi} =
+      :aesc_utils.accounts_in_poi(
+        Enum.map(accounts, fn account ->
+          {:account_pubkey, puk_key_binary} = :aeser_api_encoder.decode(account)
+          puk_key_binary
+        end),
+        poi
+      )
+
+    Logger.debug("Accounts in poi are: #{inspect(accounts_in_poi)}")
+
+    Enum.map(accounts_in_poi, fn account ->
+      Logger.debug("Balance is #{inspect(:aec_accounts.balance(account))}")
+    end)
   end
 end

--- a/apps/ae_socket_connector/lib/signer.ex
+++ b/apps/ae_socket_connector/lib/signer.ex
@@ -3,6 +3,7 @@ defmodule Signer do
   require Logger
   alias SocketConnector.Update
 
+  # TODO merge this with sign_transaction
   def sign_aetx(aetx, state) do
     bin = :aetx.serialize_to_binary(aetx)
     bin_for_network = <<state.network_id::binary, bin::binary>>
@@ -30,10 +31,6 @@ defmodule Signer do
         verify_hook
       ) do
     %Update{tx: to_sign, round_initiator: round_initiator} = pending_update
-    {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, to_sign)
-    # returns #aetx
-    deserialized_signed_tx = :aetx_sign.deserialize_from_binary(signed_tx)
-    aetx = :aetx_sign.tx(deserialized_signed_tx)
 
     case poi_encoded do
       nil ->
@@ -57,6 +54,11 @@ defmodule Signer do
 
         # aeu_mp_trees
     end
+
+    {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, to_sign)
+    # returns #aetx
+    deserialized_signed_tx = :aetx_sign.deserialize_from_binary(signed_tx)
+    aetx = :aetx_sign.tx(deserialized_signed_tx)
 
     case verify_hook.(aetx, round_initiator, state) do
       :unsecure ->

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -797,7 +797,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.initiator_sign", %{signed_tx: signed_tx})
 
@@ -812,7 +812,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.close_solo_sign", %{signed_tx: signed_tx})
 
@@ -827,7 +827,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.responder_sign", %{signed_tx: signed_tx})
 
@@ -842,7 +842,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.deposit_tx", %{signed_tx: signed_tx})
 
@@ -857,7 +857,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.deposit_ack", %{signed_tx: signed_tx})
 
@@ -872,7 +872,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.withdraw_tx", %{signed_tx: signed_tx})
 
@@ -887,7 +887,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.withdraw_ack", %{signed_tx: signed_tx})
 
@@ -912,15 +912,10 @@ defmodule SocketConnector do
       # TODO need to check that PoI makes any sense to us
       Logger.debug("POI is: #{inspect(poi)}", state.color)
 
-      signed_tx =
-        Signer.sign_transaction_perform(
-          to_sign,
-          state,
-          &Validator.inspect_transfer_request/3
-          # Validator.inspect_transfer_request_poi(poi)
-        )
-
-      build_request(return_method, %{signed_tx: signed_tx})
+      Signer.sign_transaction(to_sign, poi, &Validator.inspect_transfer_request/3, state,
+        method: return_method,
+        logstring: "initiator/acc_sign"
+      )
     end
 
     process_poi = fn %{"result" => result}, state ->
@@ -965,6 +960,7 @@ defmodule SocketConnector do
     signed_payload =
       Signer.sign_transaction_perform(
         pending_update,
+        nil,
         state,
         &Validator.inspect_transfer_request/3
       )

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -796,8 +796,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.initiator_sign", %{signed_tx: signed_tx})
 
@@ -811,8 +810,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.close_solo_sign", %{signed_tx: signed_tx})
 
@@ -826,8 +824,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.responder_sign", %{signed_tx: signed_tx})
 
@@ -841,8 +838,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.deposit_tx", %{signed_tx: signed_tx})
 
@@ -856,8 +852,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.deposit_ack", %{signed_tx: signed_tx})
 
@@ -871,8 +866,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.withdraw_tx", %{signed_tx: signed_tx})
 
@@ -886,8 +880,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx =
-      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.withdraw_ack", %{signed_tx: signed_tx})
 
@@ -917,7 +910,7 @@ defmodule SocketConnector do
           to_sign,
           poi,
           state,
-          &Validator.inspect_transfer_request/3
+          &Validator.inspect_sign_request/3
         )
 
       response = build_request(return_method, %{signed_tx: signed_tx})
@@ -967,7 +960,7 @@ defmodule SocketConnector do
         pending_update,
         nil,
         state,
-        &Validator.inspect_transfer_request/3
+        &Validator.inspect_sign_request/3
       )
 
     # check if we have a backchannel if so request signing that way:

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -257,7 +257,6 @@ defmodule SocketConnector do
     WebSockex.cast(pid, {:get_contract_reponse, {pub_key, contract_file}, fun, from})
   end
 
-  # Server side
   @spec get_poi(pid, pid) :: :ok
   def get_poi(pid, from \\ nil) do
     WebSockex.cast(pid, {:get_poi, from})

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -797,7 +797,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.initiator_sign", %{signed_tx: signed_tx})
 
@@ -812,7 +812,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.close_solo_sign", %{signed_tx: signed_tx})
 
@@ -827,7 +827,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.responder_sign", %{signed_tx: signed_tx})
 
@@ -842,7 +842,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.deposit_tx", %{signed_tx: signed_tx})
 
@@ -857,7 +857,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.deposit_ack", %{signed_tx: signed_tx})
 
@@ -872,7 +872,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.withdraw_tx", %{signed_tx: signed_tx})
 
@@ -887,7 +887,7 @@ defmodule SocketConnector do
         state
       ) do
     signed_tx =
-      Signer.sign_transaction_perform(to_sign, nil, state, &Validator.inspect_transfer_request/3)
+      Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_transfer_request/3)
 
     response = build_request("channels.withdraw_ack", %{signed_tx: signed_tx})
 
@@ -912,10 +912,15 @@ defmodule SocketConnector do
       # TODO need to check that PoI makes any sense to us
       Logger.debug("POI is: #{inspect(poi)}", state.color)
 
-      Signer.sign_transaction(to_sign, poi, &Validator.inspect_transfer_request/3, state,
-        method: return_method,
-        logstring: "initiator/acc_sign"
-      )
+      signed_tx =
+        Signer.sign_transaction(
+          to_sign,
+          poi,
+          state,
+          &Validator.inspect_transfer_request/3
+        )
+
+      response = build_request(return_method, %{signed_tx: signed_tx})
     end
 
     process_poi = fn %{"result" => result}, state ->
@@ -958,7 +963,7 @@ defmodule SocketConnector do
     }
 
     signed_payload =
-      Signer.sign_transaction_perform(
+      Signer.sign_transaction(
         pending_update,
         nil,
         state,

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -796,7 +796,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.initiator_sign", %{signed_tx: signed_tx})
 
@@ -810,7 +810,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.close_solo_sign", %{signed_tx: signed_tx})
 
@@ -824,7 +824,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.responder_sign", %{signed_tx: signed_tx})
 
@@ -838,7 +838,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.deposit_tx", %{signed_tx: signed_tx})
 
@@ -852,7 +852,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.deposit_ack", %{signed_tx: signed_tx})
 
@@ -866,7 +866,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.withdraw_tx", %{signed_tx: signed_tx})
 
@@ -880,7 +880,7 @@ defmodule SocketConnector do
         } = _message,
         state
       ) do
-    signed_tx = Signer.sign_transaction(to_sign, nil, state, &Validator.inspect_sign_request/3)
+    signed_tx = Signer.sign_transaction(to_sign, state, &Validator.inspect_sign_request/3)
 
     response = build_request("channels.withdraw_ack", %{signed_tx: signed_tx})
 
@@ -908,12 +908,11 @@ defmodule SocketConnector do
       signed_tx =
         Signer.sign_transaction(
           to_sign,
-          poi,
           state,
-          &Validator.inspect_sign_request/3
+          Validator.inspect_sign_request_poi(poi)
         )
 
-      response = build_request(return_method, %{signed_tx: signed_tx})
+      build_request(return_method, %{signed_tx: signed_tx})
     end
 
     process_poi = fn %{"result" => result}, state ->
@@ -958,7 +957,6 @@ defmodule SocketConnector do
     signed_payload =
       Signer.sign_transaction(
         pending_update,
-        nil,
         state,
         &Validator.inspect_sign_request/3
       )

--- a/apps/ae_socket_connector/lib/validator.ex
+++ b/apps/ae_socket_connector/lib/validator.ex
@@ -127,15 +127,24 @@ defmodule Validator do
     end
   end
 
-  @ae_http_url "http://localhost:3013"
-
+  @ae_transaction_path "/v2/transactions/"
   # shot this curl to check wheater onchain is alright....
-  def verify_on_chain(tx) do
+  def verify_on_chain(tx, ws_url) do
     {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, tx)
     deserialized_tx = :aetx_sign.deserialize_from_binary(signed_tx)
     tx_hash = :aetx_sign.hash(deserialized_tx)
     serialized_hash = :aeser_api_encoder.encode(:tx_hash, tx_hash)
-    url_to_check = "http://localhost:3013/v2/transactions/" <> URI.encode(serialized_hash)
+
+    %URI{host: host, authority: _authority} = URI.parse(ws_url)
+
+    url_to_check =
+      URI.to_string(%URI{
+        host: host,
+        port: 3013,
+        scheme: "http",
+        path: @ae_transaction_path <> URI.encode(serialized_hash)
+      })
+
     Logger.debug("url to check: curl #{inspect(url_to_check)}")
   end
 

--- a/apps/ae_socket_connector/lib/validator.ex
+++ b/apps/ae_socket_connector/lib/validator.ex
@@ -1,6 +1,7 @@
 defmodule Validator do
   require Logger
   alias SocketConnector.WsConnection
+  alias SocketConnector.Update
 
   def get_state_hash(tx) do
     {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, tx)
@@ -9,8 +10,7 @@ defmodule Validator do
     aetx = :aetx_sign.tx(deserialized)
     {module, instance} = :aetx.specialize_callback(aetx)
     # module is :aesc_offchain_tx or :aesc_create_tx
-    hash = apply(module, :state_hash, [instance])
-    Logger.debug("state hash is : #{inspect(hash)}")
+    apply(module, :state_hash, [instance])
   end
 
   def get_state_round(tx) do
@@ -20,9 +20,7 @@ defmodule Validator do
     # get aetx
     aetx = :aetx_sign.tx(deserialized)
     {module, instance} = :aetx.specialize_callback(aetx)
-    round = apply(module, :round, [instance])
-    get_state_hash(tx)
-    round
+    apply(module, :round, [instance])
   end
 
   defp channel_create_tx(tx, state) do
@@ -78,7 +76,7 @@ defmodule Validator do
 
           # apply(module, :for_client, [instance])
 
-          tranaction_type when tranaction_type in [:aesc_close_solo_tx] ->
+          trasaction_type when trasaction_type in [:aesc_close_solo_tx] ->
             %{"payload" => payload} = apply(module, :for_client, [instance])
             {:ok, signed_tx} = :aeser_api_encoder.safe_decode(:transaction, payload)
             deserialized_signed_tx = :aetx_sign.deserialize_from_binary(signed_tx)
@@ -107,6 +105,14 @@ defmodule Validator do
         :aesc_create_tx ->
           channel_create_tx(aetx, state)
 
+        :aesc_close_mutual_tx ->
+          # TODO match_pot_aetx is currently doing the same checking...
+          match_poi_aetx(
+            {poi, [state.session.initiator, state.session.responder], []},
+            aetx,
+            state.round_and_updates
+          )
+
         _other ->
           Logger.debug(
             "Sign request Missing inspection!! default approved. Module is #{inspect(module)}"
@@ -131,5 +137,93 @@ defmodule Validator do
     serialized_hash = :aeser_api_encoder.encode(:tx_hash, tx_hash)
     url_to_check = "http://localhost:3013/v2/transactions/" <> URI.encode(serialized_hash)
     Logger.debug("url to check: curl #{inspect(url_to_check)}")
+  end
+
+  defp match_poi_aetx({poi, [initiator, responder], contracts}, aetx, round_and_updates) do
+    {poi_hash, accounts_and_values} = extract_poi_hash(poi, [initiator, responder], contracts)
+    {module, instance} = :aetx.specialize_callback(aetx)
+
+    case module do
+      :aesc_close_mutual_tx ->
+        case poi_hash == get_state_hash(get_most_recent_state_tx(round_and_updates)) do
+          true ->
+            expected_after_fee = [
+              {
+                initiator,
+                apply(module, :initiator_amount_final, [instance])
+              },
+              {
+                responder,
+                apply(module, :responder_amount_final, [instance])
+              }
+            ]
+
+            Logger.debug("Values #{inspect(accounts_and_values)}")
+
+            [fee_initiator, fee_responder] =
+              Enum.map(expected_after_fee, fn {account, account_funds} ->
+                Map.get(accounts_and_values, account) - account_funds
+              end)
+
+            correct_fee_and_funds =
+              abs(fee_initiator - fee_responder) <= 1 &&
+                fee_initiator + fee_responder == apply(module, :fee, [instance])
+
+            case correct_fee_and_funds do
+              true ->
+                Logger.debug("Poi checked for module and matches well")
+                :ok
+
+              _ ->
+                Logger.error(
+                  "Poi missmatch, lets go slashing, #{inspect(fee_initiator)} #{
+                    inspect(fee_responder)
+                  } #{inspect(apply(module, :fee, [instance]))}"
+                )
+
+                :unsecure
+            end
+        end
+
+      module ->
+        # TODO if we have a POI we could at least check the the root hashes mathes
+        # poi_hash == get_state_hash(tx)
+        # Logger.debug("Poi matches most reasent state_tx #{inspect(module)}")
+        Logger.debug("PoI checking not implemented yet for #{inspect(module)}")
+        :ok
+    end
+  end
+
+  defp get_most_recent_state_tx(round_and_updates) do
+    {_round, %Update{state_tx: state_tx}} = Enum.max(round_and_updates)
+    state_tx
+  end
+
+  defp extract_poi_hash(poi_encoded, accounts, _contracts) do
+    # alternatively -spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> amount().
+    {:ok, poi_binary} = :aeser_api_encoder.safe_decode(:poi, poi_encoded)
+    poi = :aec_trees.deserialize_poi(poi_binary)
+
+    poi_hash = :aec_trees.poi_hash(poi)
+
+    # alternative
+    {:ok, accounts_in_poi} =
+      :aesc_utils.accounts_in_poi(
+        Enum.map(accounts, fn account ->
+          {:account_pubkey, pub_key_binary} = :aeser_api_encoder.decode(account)
+          pub_key_binary
+        end),
+        poi
+      )
+
+    accounts_with_values =
+      Enum.reduce(accounts_in_poi, %{}, fn account, acc ->
+        serialized_pubkey =
+          :aeser_api_encoder.encode(:account_pubkey, :aec_accounts.pubkey(account))
+
+        Map.put(acc, serialized_pubkey, :aec_accounts.balance(account))
+      end)
+
+    {poi_hash, accounts_with_values}
   end
 end

--- a/apps/ae_socket_connector/lib/validator.ex
+++ b/apps/ae_socket_connector/lib/validator.ex
@@ -94,7 +94,11 @@ defmodule Validator do
     end
   end
 
-  def inspect_sign_request(aetx, round_initiator, state) do
+  def inspect_sign_request_poi(poi) do
+    fn a, b, c -> inspect_sign_request(a, b, c, poi) end
+  end
+
+  def inspect_sign_request(aetx, round_initiator, state, poi \\ nil) do
     {module, _tx_instance} = :aetx.specialize_callback(aetx)
 
     # TODO if calls is initiated by us and contains what we submitted auto approval can be made

--- a/apps/ae_socket_connector/lib/validator.ex
+++ b/apps/ae_socket_connector/lib/validator.ex
@@ -94,7 +94,7 @@ defmodule Validator do
     end
   end
 
-  def inspect_transfer_request(aetx, round_initiator, state) do
+  def inspect_sign_request(aetx, round_initiator, state) do
     {module, _tx_instance} = :aetx.specialize_callback(aetx)
 
     # TODO if calls is initiated by us and contains what we submitted auto approval can be made

--- a/apps/ae_socket_connector/mix.exs
+++ b/apps/ae_socket_connector/mix.exs
@@ -29,14 +29,19 @@ defmodule SocketConnector.MixProject do
       # {:aebytecode, path: "../aebytecode", manager: :rebar3},
       # {:aebytecode, path: "../../aebytecode", manager: :rebar3, compile: false, override: true, app: false},
       # {:aebytecode, ">= 0.0.0", [env: :prod, override: true, git: "https://github.com/aeternity/aebytecode.git", ref: "241a96e"]},
-      {:aesophia, git: "https://github.com/aeternity/aesophia.git", ref: "73b9a54", manager: :rebar},
+      {:aesophia,
+       git: "https://github.com/aeternity/aesophia.git", ref: "73b9a54", manager: :rebar},
       # {:aeserialization, ">= 0.0.0", [env: :prod, override: true, git: "https://github.com/aeternity/aeserialization.git", ref: "816bf99", manager: :rebar3]},
       {:websockex, "~> 0.4.2"},
       {:poison, "~> 3.1"},
       {:enacl, git: "https://github.com/aeternity/enacl.git", ref: "26180f4"},
-      {:exometer_core, git: "https://github.com/aeternity/exometer_core.git", ref: "588da23", manager: :rebar3},
+      {:exometer_core,
+       git: "https://github.com/aeternity/exometer_core.git", ref: "588da23", manager: :rebar3},
+      {:meck,
+       git: "https://github.com/eproxus/meck.git", tag: "0.8.11", override: true, manager: :rebar3},
       # {:aebytecode, path: "../../aebytecode", manager: :rebar3, override: true, manager: :make},
-      {:aeserialization, git: "https://github.com/aeternity/aeserialization.git", ref: "4a07297", override: true}
+      {:aeserialization,
+       git: "https://github.com/aeternity/aeserialization.git", ref: "4a07297", override: true}
       # {:aeserialization, git: "https://github.com/aeternity/aeserialization.git"},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "hut": {:git, "git://github.com/tolbrino/hut.git", "025540398478ab6f95932c3234382ac5bb21ad3e", [tag: "v1.1.1"]},
   "jsx": {:git, "https://github.com/talentdeficit/jsx.git", "3074d4865b3385a050badf7828ad31490d860df5", [tag: "2.8.0"]},
   "lager": {:git, "https://github.com/erlang-lager/lager.git", "69b4ada2341b8ab2cf5c8e464ac936e5e4a9f62b", [ref: "69b4ada"]},
-  "meck": {:git, "https://github.com/eproxus/meck", "70d6a33ce7407029dc59e22a5b3c1c61c1348b23", [tag: "0.8.4"]},
+  "meck": {:git, "https://github.com/eproxus/meck.git", "70cfe7c67170af9d8f443c590904e11e807b7dee", [tag: "0.8.11"]},
   "parse_trans": {:git, "git://github.com/uwiger/parse_trans.git", "6f3645afb43c7c57d61b54ef59aecab288ce1013", [tag: "3.0.0"]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "setup": {:git, "git://github.com/uwiger/setup.git", "a0b5a237b6359795af24257fee41d97bf1602819", [tag: "1.8.2"]},


### PR DESCRIPTION
Added support for close mutual. On shutdown event poi is fetched:
- POI hash is matched with last co signed operation.
- POI are matched with balances in aesc_close_mutual_tx
    fee paid by both parties should match with fee found in aesc_close_mutual_tx. Initiator potentially pais 1 more (if fee is uneven)

Tests can and are now executed serialized fashion. as @tolbrino pointed out; ready for exunit

json building moved out of Signer module

renaming for improved quality/readability

removed hardcoded node links, can now run on testnet

Testcases added to reproduce https://www.pivotaltracker.com/n/projects/2124891/stories/167944617

Now runs on otp-21