### PR TITLE
node code coverage, remember to add "tools" which contains cover to n…

### DIFF
--- a/apps/ae_socket_connector/test/test_helper.exs
+++ b/apps/ae_socket_connector/test/test_helper.exs
@@ -1,1 +1,15 @@
 ExUnit.start()
+
+# node code coverage, remember to add "tools" which contains cover to node in rebar.config, as in [.. aestratum, ecrecover, tools], start node by doing elixir --sname foo -S mix test
+# need to be started using: elixir --sname foo -S mix test
+# :erlang.set_cookie(:erlang.node(), :aeternity_cookie)
+# rpc_cover = :rpc.call(:aeternity@localhost, :cover, :compile_beam, [[:aesc_fsm]])
+# Logger.error("ONCE #{inspect(rpc_cover)}")
+# rpc_cover_start = :rpc.call(:aeternity@localhost, :cover, :start, [])
+# Logger.error("ONCE #{inspect(rpc_cover_start)}")
+
+# ExUnit.after_suite(fn _ignore ->
+#   dir = File.cwd!
+#   Logger.info "output folder is: #{inspect dir}"
+#   Logger.info("coverage #{inspect(:rpc.call(:aeternity@localhost, :cover, :analyse_to_file, [[:aesc_fsm], [:html, {:outdir, dir}]]))}")
+# end)


### PR DESCRIPTION
Not ready for merge!

- [ ] Use env param to enable code


```bash
diff --git a/rebar.config b/rebar.config
index 7ecf0e7d..5e85285e 100644
--- a/rebar.config
+++ b/rebar.config
@@ -112,7 +112,7 @@
          [runtime_tools, sasl, lager, setup, sext, gproc, jobs, lz4,
           {rocksdb, load}, {mnesia_rocksdb, load}, {mnesia, load}, {leveled, load}, {mnesia_leveled, load},
           parse_trans, exometer_core, ranch, aeminer, aecore, aehttp, enacl, enoise,
-          aebytecode, aeserialization, aevm, aechannel, aefate, aemon, aestratum, ecrecover]},
+          aebytecode, aeserialization, aevm, aechannel, aefate, aemon, aestratum, ecrecover, tools]},
```