### PR TITLE
Early reestablish

### DIFF
--- a/apps/ae_backend_service/lib/backend_service_manager.ex
+++ b/apps/ae_backend_service/lib/backend_service_manager.ex
@@ -9,7 +9,8 @@ defmodule BackendServiceManager do
   use GenServer
   require Logger
 
-  defstruct pid_session_holder: nil
+  defstruct pid_session_holder: nil,
+            channel_id_table: %{}
 
   # Client
 
@@ -17,15 +18,23 @@ defmodule BackendServiceManager do
     GenServer.start_link(__MODULE__, {}, name: __MODULE__)
   end
 
+  # only one instance of the manager.
   def start_channel(params) do
     GenServer.call(__MODULE__, {:start_channel, params})
   end
 
+  def get_channel_id(pid, identifier) do
+    GenServer.call(pid, {:get_channel_id, identifier})
+  end
+
+  def set_channel_id(pid, identifier, channel_id) do
+    GenServer.call(pid, {:set_channel_id, identifier, channel_id})
+  end
 
 
   # Server
   def init({}) do
-    {:ok, %__MODULE__{}}
+    {:ok, %__MODULE__{channel_id_table: %{}}}
   end
 
   defp is_reestablish(reestablish) do
@@ -36,25 +45,44 @@ defmodule BackendServiceManager do
     end
   end
 
-  defp start_channel_local(
-        {
-          role,
-          _config,
-          {channel_id, reestablish_port} = reestablish,
-          _keypair_initiator
-        } = params
-      )
-      when role in [:initiator, :responder] do
-    if is_reestablish(reestablish) do
-      # only superview reestablished sessions, no way to relocate a fsm without channel_id and fsm_id
-      Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, self()}])
-    else
-      BackendSession.start_link({params, self()})
-    end
+  # defp start_channel_local(
+  #       {
+  #         role,
+  #         _config,
+  #         {channel_id, reestablish_port} = reestablish,
+  #         _keypair_initiator
+  #       } = params
+  #     )
+  #     when role in [:initiator, :responder] do
+  #   identifier = :erlang.unique_integer([:monotonic])
+  #   if is_reestablish(reestablish) do
+  #     # only superview reestablished sessions, no way to relocate a fsm without channel_id and fsm_id
+  #     Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self()}, identifier}])
+
+  #   # else
+  #   #   BackendSession.start_link({params, self()})
+  #   # end
+  # end
+
+  def handle_call({:get_channel_id, identifier}, _from, state) do
+    Logger.info("got channel id: #{inspect Map.get(state.channel_id_table, identifier, {"", 0})}")
+    {:reply, Map.get(state.channel_id_table, identifier, {"", 0}), state}
   end
 
-  def handle_call({:start_channel, params}, _from, state) do
-    {:ok, pid} = start_channel_local(params)
-    {:reply, pid, state}
+  def handle_call({:set_channel_id, identifier, reestablish}, _from, state) do
+    Logger.info("Channel poulated with channel_id #{inspect {reestablish, identifier}}")
+    {:reply, :ok, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, reestablish)}}
+  end
+
+  def handle_call({:start_channel, {_role, _config, reestablish, _keypair_initiator} = params}, _from, state) do
+    # {:ok, pid} = start_channel_local(params)
+    identifier = :erlang.unique_integer([:monotonic])
+    {:ok, pid} = Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self(), identifier}}])
+    case is_reestablish(reestablish) do
+      true ->
+        {:reply, pid, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, reestablish)}}
+      false ->
+        {:reply, pid, state}
+    end
   end
 end

--- a/apps/ae_backend_service/lib/backend_service_manager.ex
+++ b/apps/ae_backend_service/lib/backend_service_manager.ex
@@ -10,13 +10,20 @@ defmodule BackendServiceManager do
   require Logger
 
   defstruct pid_session_holder: nil,
+            # %{identifier => channel_id}
             channel_id_table: %{}
 
   # Client
 
+  # for testing
+  def start_link(%{"name" => name}) do
+    GenServer.start_link(__MODULE__, {}, name: name)
+  end
+
   def start_link(_arg) do
     GenServer.start_link(__MODULE__, {}, name: __MODULE__)
   end
+
 
   # only one instance of the manager.
   def start_channel(params) do
@@ -45,44 +52,39 @@ defmodule BackendServiceManager do
     end
   end
 
-  # defp start_channel_local(
-  #       {
-  #         role,
-  #         _config,
-  #         {channel_id, reestablish_port} = reestablish,
-  #         _keypair_initiator
-  #       } = params
-  #     )
-  #     when role in [:initiator, :responder] do
-  #   identifier = :erlang.unique_integer([:monotonic])
-  #   if is_reestablish(reestablish) do
-  #     # only superview reestablished sessions, no way to relocate a fsm without channel_id and fsm_id
-  #     Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self()}, identifier}])
 
-  #   # else
-  #   #   BackendSession.start_link({params, self()})
-  #   # end
-  # end
+  def is_already_started(channel_id_table, {channel_id, _port}) do
+    case (for {_identifier, {{existing_channel_id, _existing_port}, pid}} <- channel_id_table, channel_id == existing_channel_id, do: pid) do
+      [pid] -> pid
+      [] -> nil
+    end
+  end
 
   def handle_call({:get_channel_id, identifier}, _from, state) do
     Logger.info("got channel id: #{inspect Map.get(state.channel_id_table, identifier, {"", 0})}")
-    {:reply, Map.get(state.channel_id_table, identifier, {"", 0}), state}
+    {reestablish, _pid} = Map.get(state.channel_id_table, identifier, {{"", 0}, nil})
+    {:reply, reestablish, state}
   end
 
-  def handle_call({:set_channel_id, identifier, reestablish}, _from, state) do
-    Logger.info("Channel poulated with channel_id #{inspect {reestablish, identifier}}")
-    {:reply, :ok, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, reestablish)}}
+  def handle_call({:set_channel_id, identifier, reestablish}, from, state) do
+    Logger.info("Channel poulated with channel_id #{inspect {identifier, reestablish}}")
+    {:reply, :ok, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, {reestablish, from})}}
   end
 
   def handle_call({:start_channel, {_role, _config, reestablish, _keypair_initiator} = params}, _from, state) do
-    # {:ok, pid} = start_channel_local(params)
     identifier = :erlang.unique_integer([:monotonic])
-    {:ok, pid} = Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self(), identifier}}])
     case is_reestablish(reestablish) do
       true ->
-        {:reply, pid, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, reestablish)}}
+        case is_already_started(state.channel_id_table, reestablish) do
+          nil ->
+            {:ok, pid} = Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self(), identifier}}])
+            {:reply, {:ok, pid}, %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, {reestablish, pid})}}
+          pid ->
+            {:reply, {:ok, pid}, state}
+        end
       false ->
-        {:reply, pid, state}
+        {:ok, pid} = Supervisor.start_child(ChannelSupervisor.Supervisor, [{params, {self(), identifier}}])
+        {:reply, {:ok, pid}, state}
     end
   end
 end

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -19,12 +19,14 @@ defmodule BackendSession do
 
 
   defstruct pid_session_holder: nil,
-            pid_backend_manager: nil
+            pid_backend_manager: nil,
+            identifier: nil,
+            port: nil
 
   #Client
 
-  def start_link({params, pid_manager}) do
-    GenServer.start_link(__MODULE__, {params, pid_manager})
+  def start_link({params, {_pid_manager, _identifier} = manager_data}) do
+    GenServer.start_link(__MODULE__, {params, manager_data})
   end
 
   defp log_callback({type, message}) do
@@ -35,10 +37,16 @@ defmodule BackendSession do
   end
 
   #Server
-  def init({{role, channel_config, {_channel_id, _reestablish_port} = reestablish, initiator_keypair} = params, pid_manager}) do
-    Logger.info("Starting backend session #{inspect params} pid is #{inspect self()}")
+  def init({params, {pid_manager, identifier}}) do
+    Logger.info("Starting backend session #{inspect {params, identifier}} pid is #{inspect self()}")
+    GenServer.cast(self(), {:resume_init, params})
+    {:ok, %__MODULE__{pid_backend_manager: pid_manager, identifier: identifier}}
+  end
+
+  def handle_cast({:resume_init, {role, channel_config, _reestablish, initiator_keypair}}, state) do
+    {_channel_id, port} = reestablish = BackendServiceManager.get_channel_id(state.pid_backend_manager, state.identifier)
     {:ok, pid} = SessionHolderHelper.start_session_holder(role, channel_config, reestablish, initiator_keypair, fn -> keypair_responder() end, SessionHolderHelper.connection_callback(self(), :blue, &log_callback/1))
-    {:ok, %__MODULE__{pid_session_holder: pid, pid_backend_manager: pid_manager}}
+    {:noreply, %__MODULE__{state | pid_session_holder: pid, port: port}}
   end
 
   #TODO once we know the channel_id this process should register itself somewhere.
@@ -47,7 +55,11 @@ defmodule BackendSession do
   end
 
   # TODO backend just happily signs
-  def handle_cast({:match_jobs, {:sign_approve, _round, _round_initiator, method, _channel_id}, to_sign} = _message, state) do
+  def handle_cast({:match_jobs, {:sign_approve, _round, _round_initiator, method, channel_id}, to_sign} = _message, state) do
+    if (method == "channels.sign.responder_sign") do
+      BackendServiceManager.set_channel_id(state.pid_backend_manager, state.identifier, {channel_id, state.port})
+    end
+
     signed = SessionHolder.sign_message(state.pid_session_holder, to_sign)
     fun = &SocketConnector.send_signed_message(&1, method, signed)
     SessionHolder.run_action(state.pid_session_holder, fun)
@@ -59,8 +71,8 @@ defmodule BackendSession do
     {:noreply, state}
   end
 
-  def handle_cast(message, socket) do
+  def handle_cast(message, state) do
     Logger.warn("unprocessed message received in backend #{inspect(message)}")
-    {:noreply, socket}
+    {:noreply, state}
   end
 end

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -12,7 +12,7 @@ defmodule BackendSession do
   defmacro keypair_initiator, do: Application.get_env(:ae_socket_connector, :accounts)[:initiator]
   defmacro keypair_responder, do: Application.get_env(:ae_socket_connector, :accounts)[:responder]
 
-  defmacro ae_url, do: Application.get_env(:ae_socket_connector, :node)[:ae_url]
+  @ae_url Application.get_env(:ae_socket_connector, :node)[:ae_url]
 
   defmacro network_id, do: Application.get_env(:ae_socket_connector, :node)[:network_id]
 
@@ -63,10 +63,6 @@ defmodule BackendSession do
     signed = SessionHolder.sign_message(state.pid_session_holder, to_sign)
     fun = &SocketConnector.send_signed_message(&1, method, signed)
     SessionHolder.run_action(state.pid_session_holder, fun)
-
-    if method == "channels.sign.responder_sign" do
-
-    end
 
     {:noreply, state}
   end

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -75,7 +75,7 @@ defmodule BackendSession do
   end
 
   # once this occured we should be able to reconnect.
-  def handle_cast({:match_jobs, {:channels_info, _round, _round_initiator, method, channel_id}, _}, state) when method in ["funding_signed", "funding_created"] do
+  def handle_cast({:match_jobs, {:channels_info, method, channel_id}, _}, state) when method in ["funding_signed", "funding_created"] do
     BackendServiceManager.set_channel_id(state.pid_backend_manager, state.identifier, {channel_id, state.port})
     {:noreply, state}
   end

--- a/apps/ae_backend_service/lib/contacts/tictactoe.aes
+++ b/apps/ae_backend_service/lib/contacts/tictactoe.aes
@@ -1,0 +1,83 @@
+//  the tic-tac-toe game
+include "List.aes"
+
+contract TicTacToe =
+
+  record state = { player : address,
+                   price_sum : int,
+                   deadline : int,
+                   next : address,   // first one doign a move starts, agreed in channel (otherwise not signed)
+                   board : map(int * int, option(address)) }
+
+  entrypoint init() : state =
+    { player = Contract.creator,
+      price_sum = Contract.balance,
+      deadline = 0,
+      next = Contract.creator,
+      board = {[(0,0)] = None, [(0,1)] = None, [(0,2)] = None,
+               [(1,0)] = None, [(1,1)] = None, [(1,2)] = None,
+               [(2,0)] = None, [(2,1)] = None, [(2,2)] = None} }
+
+  // check in state channel whether you want to sign for this call value
+  // in channel check whether you accept the joiner to start or follow
+  stateful payable entrypoint join(start : bool) =
+    require( state.player == state.next, "already 2 players")
+    require( state.price_sum > 0, "no price")
+    require( state.player != Call.caller, "It's a 2 player game")
+    require( Call.value == state.price_sum, String.concat("To play you need to pay: ", Int.to_str(state.price_sum)))
+    switch(start)
+        true =>
+           put( state{ player = Call.caller,
+                       deadline = Chain.block_height + 2,
+                       price_sum = state.price_sum + Call.value } )
+        false =>
+           put( state{ next = Call.caller,
+                       deadline = Chain.block_height + 3,  // one extra block if other party starts
+                       price_sum = state.price_sum + Call.value } )
+
+  stateful entrypoint move(row : int, column : int) =
+    require( state.player != state.next, "only one player")
+    // require( state.player == Call.caller || state.deadline < Chain.block_height, "not your turn")
+    require( state.player == Call.caller, "not your turn")
+    require( state.price_sum > 0, "no price")
+    require( 0 =< row && row =< 3, "only 3 rows")
+    require( 0 =< column && column =< 3, "only 3 columns")
+    // if(state.deadline < Chain.block_height)
+    if(false)
+       Chain.spend(state.next, state.price_sum)
+       put(state{ price_sum = 0 })
+       true
+    else
+      require( state.board[(row, column)] == None, "already taken")
+      put(state{ next = state.player,
+                 player = state.next,
+                 deadline = Chain.block_height + 2,
+                 board = state.board{[(row, column)] = Some(Call.caller)} })
+      switch(check_winning())
+        None => false
+        Some(winner) =>
+           Chain.spend(winner, state.price_sum)
+           put(state{ price_sum = 0 })
+           true
+
+
+  function check_winning() : option(address) =
+    if(won(state.board[(0,0)], state.board[(0,1)], state.board[(0,2)]) ||
+       won(state.board[(0,0)], state.board[(1,1)], state.board[(2,2)]) ||
+       won(state.board[(0,0)], state.board[(1,0)], state.board[(2,0)]))
+      state.board[(0,0)]
+    elif(won(state.board[(1,1)], state.board[(0,1)], state.board[(2,1)]) ||
+         won(state.board[(1,1)], state.board[(1,0)], state.board[(1,2)]) ||
+         won(state.board[(1,1)], state.board[(0,2)], state.board[(2,0)]))
+      state.board[(1,1)]
+    elif(won(state.board[(2,2)], state.board[(0,2)], state.board[(1,2)]) ||
+         won(state.board[(2,2)], state.board[(2,0)], state.board[(2,1)]))
+      state.board[(2,2)]
+    else
+      None
+
+  function won(a, b, c) =
+     a != None && a == b && a ==c
+
+  entrypoint get_state() =
+    state

--- a/apps/ae_backend_service/test/backend_session_test.exs
+++ b/apps/ae_backend_service/test/backend_session_test.exs
@@ -5,4 +5,29 @@ defmodule AeBackendServiceTest do
   # test "greets the world" do
   #   assert AeBackendService.hello() == :world
   # end
+
+  test "backend dosen't allow restarting running channels" do
+    {:ok, pid} = BackendServiceManager.start_link(%{"name" => :some_name})
+    unique_id = 1234
+    other_id = 234
+    reestablish = {"channel_id", 2332}
+    BackendServiceManager.set_channel_id(pid, unique_id, reestablish)
+    reestablish = BackendServiceManager.get_channel_id(pid, unique_id)
+    {"", 0} = BackendServiceManager.get_channel_id(pid, other_id)
+    reestablish2 = {"channel_id2", 23322}
+    BackendServiceManager.set_channel_id(pid, unique_id, reestablish)
+    reestablish2 = BackendServiceManager.get_channel_id(pid, unique_id)
+  end
+
+  test "returns present pid if started" do
+    unique_id = 1234
+    reestablish = {"channel_id", 2332}
+    unique_id2 = 12342
+    reestablish2 = {"channel_id2", 23322}
+    pid_self = self()
+    pid_other = 12314421
+    channel_id_table = %{unique_id => {reestablish, pid_self}, unique_id2 => {reestablish2, pid_other}}
+    assert pid_self == BackendServiceManager.is_already_started(channel_id_table, {"channel_id", 1111})
+    assert nil == BackendServiceManager.is_already_started(channel_id_table, {"channel_id_new", 1112})
+  end
 end

--- a/apps/ae_channel_interface/.gitignore
+++ b/apps/ae_channel_interface/.gitignore
@@ -32,3 +32,6 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+# default storage path
+/data

--- a/apps/ae_channel_interface/assets/js/app.js
+++ b/apps/ae_channel_interface/assets/js/app.js
@@ -174,6 +174,8 @@ connect_initiator_websocket_btn.addEventListener('click', function (event) {
     channel.on('sign', function (payload) {
         sign_msg.value = payload.to_sign
         sign_mthd.value = payload.method
+        channel_id.value = payload.channel_id
+        connect_btn.textContent = "Reestablish"
     });
 
     channel.on('connected', function (payload) {

--- a/apps/ae_channel_interface/assets/js/app.js
+++ b/apps/ae_channel_interface/assets/js/app.js
@@ -82,6 +82,10 @@ connect_port.addEventListener('input', function (updatevalue) {
     updateBackendParams(connect_port.value, channel_id.value, public_key.value)
 });
 
+channel_id.addEventListener('change', function (updatevalue) {
+    updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+});
+
 channel_id.addEventListener('input', function (updatevalue) {
     if (channel_id.value == "") {
         connect_btn.textContent = "Connect"
@@ -173,12 +177,14 @@ connect_initiator_websocket_btn.addEventListener('click', function (event) {
 
     channel.on('sign_approve', function (payload) {
         sign_msg.value = payload.to_sign
-        sign_mthd.value = payload.method
+        sign_mthd.value = payload.method        
     });
 
     channel.on('channels_info', function (payload) {
         channel_id.value = payload.channel_id
         connect_btn.textContent = "Reestablish"
+        var event = new Event('input');
+        channel_id.dispatchEvent(event);
     });
 
     channel.on('connected', function (payload) {
@@ -218,6 +224,8 @@ connect_responder_websocket_btn.addEventListener('click', function (event) {
     channel.on('channels_info', function (payload) {
         channel_id.value = payload.channel_id
         connect_btn.textContent = "Reestablish"
+        var event = new Event('input');
+        channel_id.dispatchEvent(event);
     });
 
     channel.on('connected', function (payload) {

--- a/apps/ae_channel_interface/assets/js/app.js
+++ b/apps/ae_channel_interface/assets/js/app.js
@@ -171,9 +171,12 @@ connect_initiator_websocket_btn.addEventListener('click', function (event) {
         ul.appendChild(li);                    // append to list
     });
 
-    channel.on('sign', function (payload) {
+    channel.on('sign_approve', function (payload) {
         sign_msg.value = payload.to_sign
         sign_mthd.value = payload.method
+    });
+
+    channel.on('channels_info', function (payload) {
         channel_id.value = payload.channel_id
         connect_btn.textContent = "Reestablish"
     });
@@ -207,9 +210,14 @@ connect_responder_websocket_btn.addEventListener('click', function (event) {
         ul.appendChild(li);                    // append to list
     });
 
-    channel.on('sign', function (payload) {
+    channel.on('sign_approve', function (payload) {
         sign_msg.value = payload.to_sign
         sign_mthd.value = payload.method
+    });
+
+    channel.on('channels_info', function (payload) {
+        channel_id.value = payload.channel_id
+        connect_btn.textContent = "Reestablish"
     });
 
     channel.on('connected', function (payload) {

--- a/apps/ae_channel_interface/assets/js/socket.js
+++ b/apps/ae_channel_interface/assets/js/socket.js
@@ -55,9 +55,9 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+// let channel = socket.channel("topic:subtopic", {})
+// channel.join()
+//   .receive("ok", resp => { console.log("Joined successfully", resp) })
+//   .receive("error", resp => { console.log("Unable to join", resp) })
 
 export default socket

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
@@ -87,9 +87,15 @@ defmodule AeChannelInterfaceWeb.SocketConnectorChannel do
 
   def handle_cast({:match_jobs, {:sign_approve, _round, _round_initiator, method, channel_id}, to_sign} = message, socket) do
     Logger.info("Sign request #{inspect(message)}")
-    push(socket, "sign", %{message: inspect(message), method: method, to_sign: to_sign, channel_id: channel_id})
+    push(socket, "sign_approve", %{message: inspect(message), method: method, to_sign: to_sign, channel_id: channel_id})
     push(socket, "log_event", %{message: inspect(message), name: "bot"})
     # broadcast socket, "log_event", %{message: inspect(message), name: "bot2"}
+    {:noreply, socket}
+  end
+
+  def handle_cast({:match_jobs, {:channels_info, _round, _round_initiator, method, channel_id}, _} = message, socket) when method in ["funding_signed", "funding_created"] do
+    push(socket, "channels_info", %{message: inspect(message), method: method, channel_id: channel_id})
+    push(socket, "log_event", %{message: inspect(message), name: "bot"})
     {:noreply, socket}
   end
 

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
@@ -93,7 +93,7 @@ defmodule AeChannelInterfaceWeb.SocketConnectorChannel do
     {:noreply, socket}
   end
 
-  def handle_cast({:match_jobs, {:channels_info, _round, _round_initiator, method, channel_id}, _} = message, socket) when method in ["funding_signed", "funding_created"] do
+  def handle_cast({:match_jobs, {:channels_info, method, channel_id}, _} = message, socket) when method in ["funding_signed", "funding_created"] do
     push(socket, "channels_info", %{message: inspect(message), method: method, channel_id: channel_id})
     push(socket, "log_event", %{message: inspect(message), name: "bot"})
     {:noreply, socket}

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
@@ -6,6 +6,9 @@ defmodule AeChannelInterfaceWeb.ConnectController do
   require Logger
   require SessionHolderHelper
 
+  @ae_url Application.get_env(:ae_socket_connector, :node)[:ae_url]
+
+
   def public_key() do
     {responder_pub_key, _responder_priv_key} = SocketConnectorChannel.keypair_responder()
     responder_pub_key
@@ -29,7 +32,7 @@ defmodule AeChannelInterfaceWeb.ConnectController do
     open_port = String.to_integer(port)
     channel_config = SessionHolderHelper.custom_config(%{}, %{port: open_port})
     basic_params = channel_config.(client_account, public_key())
-    custom_params = channel_config.(client_account, public_key()).custom_param_fun.(:initiator, SessionHolderHelper.ae_url())
+    custom_params = channel_config.(client_account, public_key()).custom_param_fun.(:initiator, @ae_url)
     BackendServiceManager.start_channel({:responder, channel_config, {"", 0}, fn -> {client_account, "not for you to have"} end})
     json conn, %{account: public_key(), client_account: client_account, api_endpoint: "connect", client: params,  expected_initiator_configuration: %{basic: Map.from_struct(basic_params.basic_configuration), custom: custom_params}}
   end

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
@@ -20,11 +20,9 @@ defmodule AeChannelInterfaceWeb.ConnectController do
     # {:ok, backend_runner_pid} = BackendServiceManager.start_channel({"bogus", :some_name})
     reestablish_port = String.to_integer(port)
     channel_config = SessionHolderHelper.custom_config(%{}, %{})
-    BackendServiceManager.start_channel({:responder, channel_config, {channel_id, reestablish_port}, fn -> {client_account, "not for you to have"} end})
+    {:ok, _pid} = BackendServiceManager.start_channel({:responder, channel_config, {channel_id, reestablish_port}, fn -> {client_account, "not for you to have"} end})
     json conn, %{account: public_key(), client_account: client_account, channel_id: channel_id, api_endpoint: "reestablish", client: params}
   end
-
-  #TODO endpoint which allows custom configuration
 
   # http://127.0.0.1:4000/connect/new?client_account=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610
   # this is a brand new connection
@@ -33,7 +31,7 @@ defmodule AeChannelInterfaceWeb.ConnectController do
     channel_config = SessionHolderHelper.custom_config(%{}, %{port: open_port})
     basic_params = channel_config.(client_account, public_key())
     custom_params = channel_config.(client_account, public_key()).custom_param_fun.(:initiator, @ae_url)
-    BackendServiceManager.start_channel({:responder, channel_config, {"", 0}, fn -> {client_account, "not for you to have"} end})
+    {:ok, _pid} = BackendServiceManager.start_channel({:responder, channel_config, {"", 0}, fn -> {client_account, "not for you to have"} end})
     json conn, %{account: public_key(), client_account: client_account, api_endpoint: "connect", client: params,  expected_initiator_configuration: %{basic: Map.from_struct(basic_params.basic_configuration), custom: custom_params}}
   end
 

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -132,7 +132,7 @@ defmodule SessionHolder do
     dets_state = %{time: (DateTime.utc_now |> DateTime.to_string()), state: socketconnector_state}
 
     case socketconnector_state.channel_id do
-      nil -> Logger.warn("Not persisting to disk, channel_id missing")
+      nil -> Logger.warn("Not persisting to disk, channel_id missing, role #{inspect socketconnector_state.role}")
       _ ->
         case :dets.insert(file_ref, {socketconnector_state.channel_id, dets_state}) do
           :ok ->
@@ -140,12 +140,12 @@ defmodule SessionHolder do
               :ok -> :ok
                 case socketconnector_state.fsm_id == nil do
                   true ->
-                    Logger.warn("Persisted data not satisfying reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id}")
+                    Logger.warn("Persisted data not satisfing reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                   false ->
-                    Logger.info("Persisted data SATISFYING reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id}")
+                    Logger.info("Persisted data SATISFING reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                 end
 
-              {:error, reason} -> Logger.error("Failed to persist state to disk, fsm_id: #{inspect dets_state.fsm_id} channel_id #{inspect dets_state.channel_id} reason #{inspect reason}")
+              {:error, reason} -> Logger.error("Failed to persist state to disk, fsm_id: #{inspect dets_state.fsm_id} channel_id #{inspect dets_state.channel_id} reason #{inspect reason} role #{inspect socketconnector_state.role}")
             end
         end
     end

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -140,7 +140,7 @@ defmodule SessionHolder do
               :ok -> :ok
                 case socketconnector_state.fsm_id == nil do
                   true ->
-                    Logger.warn("Persisted data not satisfing reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
+                    Logger.warn("Persisted data not satisfying reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                   false ->
                     Logger.info("Persisted data SATISFING reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                 end

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -142,7 +142,7 @@ defmodule SessionHolder do
                   true ->
                     Logger.warn("Persisted data not satisfying reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                   false ->
-                    Logger.info("Persisted data SATISFING reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
+                    Logger.info("Persisted data SATISFYING reestablish requirements, fsm_id: #{inspect socketconnector_state.fsm_id} channel_id #{inspect socketconnector_state.channel_id} role #{inspect socketconnector_state.role}")
                 end
 
               {:error, reason} -> Logger.error("Failed to persist state to disk, fsm_id: #{inspect dets_state.fsm_id} channel_id #{inspect dets_state.channel_id} reason #{inspect reason} role #{inspect socketconnector_state.role}")

--- a/apps/ae_socket_connector/lib/session_holder.ex
+++ b/apps/ae_socket_connector/lib/session_holder.ex
@@ -161,7 +161,7 @@ defmodule SessionHolder do
   end
 
   defp get_most_recent(list, channel_id, key) do
-    Logger.warn("Missing key #{inspect key}, fetching from old entry... #{inspect list}")
+    Logger.warn("Missing key #{inspect key}, fetching from old entry...")
     case Enum.find(Enum.reverse(list), fn({_, entry}) -> Map.get(entry.state, key) != nil end) do
       nil ->
         Logger.error "Error could not find value for #{inspect key}"

--- a/apps/ae_socket_connector/lib/session_holder_helper.ex
+++ b/apps/ae_socket_connector/lib/session_holder_helper.ex
@@ -1,7 +1,12 @@
 defmodule SessionHolderHelper do
 
-  defmacro ae_url, do: Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  defmacro network_id, do: Application.get_env(:ae_socket_connector, :node)[:network_id]
+  def ae_url() do
+    Application.get_env(:ae_socket_connector, :node)[:ae_url]
+  end
+
+  def network_id() do
+    Application.get_env(:ae_socket_connector, :node)[:network_id]
+  end
 
   def connection_callback(callback_pid, color, logfun \\ &(&1)) when is_atom(color) do
     %SocketConnector.ConnectionCallbacks{

--- a/apps/ae_socket_connector/lib/session_holder_helper.ex
+++ b/apps/ae_socket_connector/lib/session_holder_helper.ex
@@ -15,17 +15,17 @@ defmodule SessionHolderHelper do
         GenServer.cast(callback_pid, {:match_jobs, {:sign_approve, round, round_initiator, method, channel_id}, to_sign})
         auto_approval
       end,
-      channels_info: fn round_initiator, round, method, channel_id ->
-        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, channel_id: channel_id, color: color}})
-        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, round, round_initiator, method, channel_id}, nil})
+      channels_info: fn method, channel_id ->
+        logfun.({:channels_info, %{method: method, channel_id: channel_id, color: color}})
+        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, method, channel_id}, nil})
       end,
       channels_update: fn round_initiator, round, method ->
         logfun.({:channels_update, %{round_initiator: round_initiator, round: round, method: method, color: color}})
         GenServer.cast(callback_pid, {:match_jobs, {:channels_update, round, round_initiator, method}, nil})
       end,
-      on_chain: fn round_initiator, round, method ->
-        logfun.({:on_chain, %{round_initiator: round_initiator, round: round, method: method, color: color}})
-        GenServer.cast(callback_pid, {:match_jobs, {:on_chain, round, round_initiator, method}, nil})
+      on_chain: fn info, _channel_id ->
+        logfun.({:on_chain, %{info: info, color: color}})
+        GenServer.cast(callback_pid, {:match_jobs, {:on_chain, info}, nil})
       end,
       connection_update: fn status, reason ->
         logfun.({:connection_update, %{status: status, reason: reason, color: color}})
@@ -41,17 +41,17 @@ defmodule SessionHolderHelper do
         GenServer.cast(callback_pid, {:match_jobs, {:sign_approve, round, method}, to_sign})
         auto_approval
       end,
-      channels_info: fn round_initiator, round, method, channel_id ->
-        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, channel_id: channel_id, color: color}})
-        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, round, round_initiator, method}, nil})
+      channels_info: fn method, channel_id ->
+        logfun.({:channels_info, %{method: method, channel_id: channel_id, color: color}})
+        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, method}, nil})
       end,
       channels_update: fn round_initiator, round, method ->
         logfun.({:channels_update, %{round_initiator: round_initiator, round: round, method: method, color: color}})
         GenServer.cast(callback_pid, {:match_jobs, {:channels_update, round, round_initiator, method}, nil})
       end,
-      on_chain: fn round_initiator, round, method ->
-        logfun.({:on_chain, %{round_initiator: round_initiator, round: round, method: method, color: color}})
-        GenServer.cast(callback_pid, {:match_jobs, {:on_chain, round, round_initiator, method}, nil})
+      on_chain: fn info, _channel_id ->
+        logfun.({:on_chain, %{info: info, color: color}})
+        GenServer.cast(callback_pid, {:match_jobs, {:on_chain, info}, nil})
       end,
       connection_update: fn status, reason ->
         logfun.({:connection_update, %{status: status, reason: reason, color: color}})

--- a/apps/ae_socket_connector/lib/session_holder_helper.ex
+++ b/apps/ae_socket_connector/lib/session_holder_helper.ex
@@ -15,9 +15,9 @@ defmodule SessionHolderHelper do
         GenServer.cast(callback_pid, {:match_jobs, {:sign_approve, round, round_initiator, method, channel_id}, to_sign})
         auto_approval
       end,
-      channels_info: fn round_initiator, round, method ->
-        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, color: color}})
-        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, round, round_initiator, method}, nil})
+      channels_info: fn round_initiator, round, method, channel_id ->
+        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, channel_id: channel_id, color: color}})
+        GenServer.cast(callback_pid, {:match_jobs, {:channels_info, round, round_initiator, method, channel_id}, nil})
       end,
       channels_update: fn round_initiator, round, method ->
         logfun.({:channels_update, %{round_initiator: round_initiator, round: round, method: method, color: color}})
@@ -41,8 +41,8 @@ defmodule SessionHolderHelper do
         GenServer.cast(callback_pid, {:match_jobs, {:sign_approve, round, method}, to_sign})
         auto_approval
       end,
-      channels_info: fn round_initiator, round, method ->
-        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, color: color}})
+      channels_info: fn round_initiator, round, method, channel_id ->
+        logfun.({:channels_info, %{round_initiator: round_initiator, round: round, method: method, channel_id: channel_id, color: color}})
         GenServer.cast(callback_pid, {:match_jobs, {:channels_info, round, round_initiator, method}, nil})
       end,
       channels_update: fn round_initiator, round, method ->

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -85,7 +85,7 @@ defmodule SocketConnector do
     session_map = init_map(session, role, ws_base)
 
     ws_url = create_link(ws_base, session_map)
-    Logger.debug("start_link #{inspect(ws_url)}", ansi_color: color)
+    Logger.error("start_link #{inspect(ws_url)}", ansi_color: color)
 
     {:ok, pid} =
       WebSockex.start_link(ws_url, __MODULE__, %__MODULE__{

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -854,12 +854,6 @@ defmodule SocketConnector do
     |> URI.to_string()
   end
 
-  # IMPORTANT!
-  # The message channels.sign.initiator_sign and channels.sign.responder_sign  nitiator_sign are of extra importance
-  # because once arrive the clinet have all credentials needed for a reestablish, allowing the client
-  # to disconnect. Keys are channel_id, fsm_id, and the state_tx. Remember the keep these _and_ update them
-  # accordingly.
-  #
   # Note, these doesn't contain round...
   def process_message(
         %{
@@ -875,7 +869,7 @@ defmodule SocketConnector do
              "channels.sign.shutdown_sign",
              "channels.sign.shutdown_sign_ack"
            ] do
-    Validator.notify_sign_transaction(to_sign, method, state)
+    Validator.notify_sign_transaction(to_sign, method, state.channel_id, state)
     {:ok, state}
   end
 
@@ -892,6 +886,12 @@ defmodule SocketConnector do
     "channels.sign.withdraw_ack"
   ]
 
+  # IMPORTANT!
+  # The message channels.sign.initiator_sign and channels.sign.responder_sign  nitiator_sign are of extra importance
+  # because once arrive the clinet have all credentials needed for a reestablish, allowing the client
+  # to disconnect. Keys are channel_id, fsm_id, and the state_tx. Remember the keep these _and_ update them
+  # accordingly.
+  #
   def process_message(
         %{
           "method" => method,
@@ -915,7 +915,7 @@ defmodule SocketConnector do
       round_initiator: round_initiator
     }
 
-    Validator.notify_sign_transaction(pending_update, method, state)
+    Validator.notify_sign_transaction(pending_update, method, channel_id, state)
 
     new_state = %__MODULE__{
        state

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -1011,7 +1011,7 @@ defmodule SocketConnector do
 
   # can be removed once this is fixed
   # https://github.com/aeternity/aeternity/issues/3186
-  def process_message(%{"channel_id" => _channel_id, "error" => %{"data" => %{"message" => "Invalid fsm id"}}} = error, state) do
+  def process_message(%{"channel_id" => _channel_id, "error" => %{"data" => [%{"message" => "Invalid fsm id"}]}} = error, state) do
     Logger.error("error")
     Logger.error("<= error unprocessed message: #{inspect(error)}", state.color)
     clean_and_exit(state, error)

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -1009,7 +1009,7 @@ defmodule SocketConnector do
     {poi, %__MODULE__{state | round_and_updates: Map.put(state.round_and_updates, round, update_new)}}
   end
 
-  # can be removed once this is fixed
+  # could possibly be removed once this is fixed
   # https://github.com/aeternity/aeternity/issues/3186
   def process_message(%{"channel_id" => _channel_id, "error" => %{"data" => [%{"message" => "Invalid fsm id"}]}} = error, state) do
     Logger.error("error")

--- a/apps/ae_socket_connector/test/ae_socket_connector_test.exs
+++ b/apps/ae_socket_connector/test/ae_socket_connector_test.exs
@@ -5,9 +5,6 @@ defmodule SocketConnectorTest do
 
   # Code.require_file "client_runner.ex", __DIR__
 
-  @ae_url Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  @network_id Application.get_env(:ae_socket_connector, :node)[:network_id]
-
   def gen_names(id) do
     clean_id = Atom.to_string(id)
     {String.to_atom("alice " <> clean_id), String.to_atom("bob " <> clean_id)}
@@ -97,8 +94,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1400})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -136,8 +133,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1401})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -198,8 +195,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1402})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -233,13 +230,13 @@ defmodule SocketConnectorTest do
            next:
              {:local,
               fn client_runner, pid_session_holder ->
-                nonce = ChannelService.OnChain.nonce(@ae_url, intiator_account)
-                height = ChannelService.OnChain.current_height(@ae_url)
+                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url(), intiator_account)
+                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url())
                 Logger.debug("nonce is #{inspect(nonce)} height is: #{inspect(height)}")
 
                 transaction = SessionHolder.solo_close_transaction(pid_session_holder, 2, nonce + 1, height)
 
-                ChannelService.OnChain.post_solo_close(@ae_url, transaction)
+                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url(), transaction)
                 ClientRunnerHelper.resume_runner(client_runner)
               end, :empty}
          }},
@@ -260,8 +257,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1403})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -306,8 +303,8 @@ defmodule SocketConnectorTest do
            next:
              {:local,
               fn client_runner, pid_session_holder ->
-                nonce = ChannelService.OnChain.nonce(@ae_url,intiator_account)
-                height = ChannelService.OnChain.current_height(@ae_url)
+                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url(),intiator_account)
+                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url())
 
                 transaction =
                   GenServer.call(
@@ -315,7 +312,7 @@ defmodule SocketConnectorTest do
                     {:solo_close_transaction, 2, nonce + 1, height}
                   )
 
-                ChannelService.OnChain.post_solo_close(@ae_url, transaction)
+                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url(), transaction)
                 ClientRunnerHelper.resume_runner(client_runner)
               end, :empty}
          }},
@@ -356,8 +353,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1404})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -427,8 +424,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1405})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -441,8 +438,8 @@ defmodule SocketConnectorTest do
   #   {alice, bob} = gen_names(context.test)
 
   #   ClientRunner.start_peers(
-  #     @ae_url,
-  #     @network_id,
+  #     SessionHolderHelper.ae_url(),
+  #     SessionHolderHelper.network_id(),
   #     %{
       #   initiator: %{name: alice, keypair: accounts_initiator()},
       #   responder: %{name: bob, keypair: accounts_responder()}
@@ -562,8 +559,8 @@ defmodule SocketConnectorTest do
     end
 
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
         responder: %{name: bob, keypair: accounts_responder()}
@@ -619,8 +616,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1406})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -673,8 +670,8 @@ defmodule SocketConnectorTest do
     end
 
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
         responder: %{name: bob, keypair: accounts_responder()}
@@ -769,8 +766,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1407})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -1037,8 +1034,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -1211,8 +1208,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}
@@ -1319,8 +1316,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
         responder: %{name: bob, keypair: accounts_responder()}
@@ -1333,8 +1330,8 @@ defmodule SocketConnectorTest do
   #   {alice, bob} = gen_names(context.test)
 
   #   ClientRunner.start_peers(
-  #     @ae_url,
-  #     @network_id,
+  #     SessionHolderHelper.ae_url(),
+  #     SessionHolderHelper.network_id(),
   #     %{
       #   initiator: %{name: alice, keypair: accounts_initiator()},
       #   responder: %{name: bob, keypair: accounts_responder()}
@@ -1401,8 +1398,8 @@ defmodule SocketConnectorTest do
 
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 50, port: 1409})
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
         responder: %{name: bob, keypair: accounts_responder(), custom_configuration: channel_config}

--- a/apps/ae_socket_connector/test/ae_socket_connector_test.exs
+++ b/apps/ae_socket_connector/test/ae_socket_connector_test.exs
@@ -48,31 +48,31 @@ defmodule SocketConnectorTest do
       [
         # opening channel
         # re-add once the node is updated to use password
-        # {:responder, %{message: {:channels_info, 0, :transient, "fsm_up"}}},
-        {:responder, %{fuzzy: 1, message: {:channels_info, 0, :transient, "channel_open"}}},
+        # {:responder, %{message: {:channels_info, "fsm_up"}}},
+        {:responder, %{fuzzy: 1, message: {:channels_info, "channel_open"}}},
         # re-add once the node is updated to use password
-        # {:initiator, %{message: {:channels_info, 0, :transient, "fsm_up"}}},
-        {:initiator, %{fuzzy: 1, message: {:channels_info, 0, :transient, "channel_accept"}}},
+        # {:initiator, %{message: {:channels_info, "fsm_up"}}},
+        {:initiator, %{fuzzy: 1, message: {:channels_info, "channel_accept"}}},
         {:initiator, %{message: {:sign_approve, 1, "channels.sign.initiator_sign"}}},
-        {:responder, %{message: {:channels_info, 0, :transient, "funding_created"}}},
+        {:responder, %{message: {:channels_info, "funding_created"}}},
         {:responder, %{message: {:sign_approve, 1, "channels.sign.responder_sign"}}},
-        {:responder, %{message: {:on_chain, 0, :transient, "funding_created"}}},
-        {:initiator, %{message: {:channels_info, 0, :transient, "funding_signed"}}},
-        {:initiator, %{message: {:on_chain, 0, :transient, "funding_signed"}}},
-        # {:responder, %{message: {:on_chain, 0, :transient, "channel_changed"}}},
-        {:responder, %{fuzzy: 1, message: {:channels_info, 0, :transient, "own_funding_locked"}}},
-        # {:initiator, %{message: {:on_chain, 0, :transient, "channel_changed"}}},
-        {:initiator, %{fuzzy: 1, message: {:channels_info, 0, :transient, "own_funding_locked"}}},
-        {:initiator, %{fuzzy: 1, message: {:channels_info, 0, :transient, "funding_locked"}}},
-        {:responder, %{fuzzy: 1, message: {:channels_info, 0, :transient, "funding_locked"}}},
-        {:initiator, %{message: {:channels_info, 0, :transient, "open"}}},
+        {:responder, %{message: {:on_chain, "funding_created"}}},
+        {:initiator, %{message: {:channels_info, "funding_signed"}}},
+        {:initiator, %{message: {:on_chain, "funding_signed"}}},
+        # {:responder, %{message: {:on_chain, "channel_changed"}}},
+        {:responder, %{fuzzy: 1, message: {:channels_info, "own_funding_locked"}}},
+        # {:initiator, %{message: {:on_chain, "channel_changed"}}},
+        {:initiator, %{fuzzy: 1, message: {:channels_info, "own_funding_locked"}}},
+        {:initiator, %{fuzzy: 1, message: {:channels_info, "funding_locked"}}},
+        {:responder, %{fuzzy: 1, message: {:channels_info, "funding_locked"}}},
+        {:initiator, %{message: {:channels_info, "open"}}},
         {:initiator,
          %{
            message: {:channels_update, 1, :self, "channels.update"},
            next: {:async, fn pid -> SocketConnector.leave(pid) end, :empty},
            fuzzy: 3
          }},
-        {:responder, %{message: {:channels_info, 0, :transient, "open"}}},
+        {:responder, %{message: {:channels_info, "open"}}},
         {:responder, %{message: {:channels_update, 1, :other, "channels.update"}}},
         # end of opening sequence
         # leaving
@@ -85,7 +85,7 @@ defmodule SocketConnectorTest do
         {:initiator, %{message: {:channels_update, 1, :transient, "channels.leave"}, fuzzy: 1}},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "died"},
+           message: {:channels_info, "died"},
            fuzzy: 0,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }}
@@ -124,7 +124,7 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "died"},
+           message: {:channels_info, "died"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }}
@@ -174,7 +174,7 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "aborted_update"},
+           message: {:channels_info, "aborted_update"},
            next: {:async, fn pid -> SocketConnector.leave(pid) end, :empty},
            fuzzy: 10
          }},
@@ -186,7 +186,7 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "died"},
+           message: {:channels_info, "died"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }}
@@ -242,13 +242,13 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:on_chain, 0, :transient, "solo_closing"},
+           message: {:on_chain, "solo_closing"},
            fuzzy: 10,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:responder,
          %{
-           message: {:on_chain, 0, :transient, "solo_closing"},
+           message: {:on_chain, "solo_closing"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, responder)
          }}
@@ -318,33 +318,33 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:on_chain, 0, :transient, "can_slash"},
+           message: {:on_chain, "can_slash"},
            fuzzy: 10,
            next: {:sync, fn pid, from -> SocketConnector.slash(pid, from) end, :empty}
            #  next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:responder,
          %{
-           message: {:on_chain, 0, :transient, "can_slash"},
+           message: {:on_chain, "can_slash"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, responder)
          }},
         {:initiator,
          %{
-           message: {:on_chain, 0, :transient, "solo_closing"},
+           message: {:on_chain, "solo_closing"},
            fuzzy: 5,
            next: {:async, fn pid -> SocketConnector.settle(pid) end, :empty}
            #  next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "closed_confirmed"},
+           message: {:channels_info, "closed_confirmed"},
            fuzzy: 10,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:responder,
          %{
-           message: {:channels_info, 0, :transient, "closed_confirmed"},
+           message: {:channels_info, "closed_confirmed"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, responder)
          }}
@@ -456,7 +456,7 @@ defmodule SocketConnectorTest do
       [
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "open"},
+           message: {:channels_info, "open"},
            next:
              {:local,
               fn client_runner, pid_session_holder ->
@@ -601,13 +601,13 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "closing"},
+           message: {:channels_info, "closing"},
            fuzzy: 15,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:responder,
          %{
-           message: {:channels_info, 0, :transient, "closing"},
+           message: {:channels_info, "closing"},
            fuzzy: 15,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, responder)
          }}
@@ -656,13 +656,13 @@ defmodule SocketConnectorTest do
          }},
         {:initiator,
          %{
-           message: {:channels_info, 0, :transient, "closed_confirmed"},
+           message: {:channels_info, "closed_confirmed"},
            fuzzy: 10,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, initiator)
          }},
         {:responder,
          %{
-           message: {:channels_info, 0, :transient, "closed_confirmed"},
+           message: {:channels_info, "closed_confirmed"},
            fuzzy: 20,
            next: ClientRunnerHelper.sequence_finish_job(runner_pid, responder)
          }}
@@ -1249,7 +1249,7 @@ defmodule SocketConnectorTest do
         {:initiator,
          %{
            fuzzy: 20,
-           message: {:channels_info, 0, :transient, "died"},
+           message: {:channels_info, "died"},
            next: ClientRunnerHelper.pause_job(300)
          }},
         {:initiator,
@@ -1264,7 +1264,7 @@ defmodule SocketConnectorTest do
         {:responder,
          %{
            fuzzy: 20,
-           # :channels_info, 0, :transient, "peer_disconnected"
+           # :channels_info, "peer_disconnected"
            message: {:channels_update, 2, :transient, "channels.leave"},
            next:
              {:local,
@@ -1350,9 +1350,9 @@ defmodule SocketConnectorTest do
         {:initiator,
          %{
            # worked before
-           # message: {:channels_info, 0, :transient, "funding_signed"},
+           # message: {:channels_info, "funding_signed"},
            # should work now
-           message: {:channels_info, 0, :transient, "own_funding_locked"},
+           message: {:channels_info, "own_funding_locked"},
            fuzzy: 10,
            next:
              {:local,

--- a/apps/ae_socket_connector/test/client_runner_test.exs
+++ b/apps/ae_socket_connector/test/client_runner_test.exs
@@ -2,9 +2,6 @@ defmodule ClientRunner do
   use GenServer
   require Logger
 
-  defmacro ae_url, do: Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  defmacro network_id, do: Application.get_env(:ae_socket_connector, :node)[:network_id]
-
   defstruct pid_session_holder: nil,
             color: nil,
             match_list: nil,

--- a/apps/ae_socket_connector/test/client_runner_test.exs
+++ b/apps/ae_socket_connector/test/client_runner_test.exs
@@ -45,7 +45,7 @@ defmodule ClientRunner do
         ae_url: ae_url,
         network_id: network_id,
         priv_key: priv_key,
-        connection_callbacks: SessionHolderHelper.connection_callback(self(), color, &log_callback/1),
+        connection_callbacks: SessionHolderHelper.connection_callback_runner(self(), color, &log_callback/1),
         color: color,
       }, name)
 
@@ -162,7 +162,7 @@ defmodule ClientRunner do
           false ->
             case Map.get(entry, :fuzzy, 0) do
               0 ->
-                throw("message not matching")
+                throw("message not matching #{inspect %{expected: entry, received: received_message}}")
 
               value ->
                 case state.fuzzy_counter >= value do

--- a/apps/ae_socket_connector/test/reuse_channel_test.exs
+++ b/apps/ae_socket_connector/test/reuse_channel_test.exs
@@ -3,14 +3,6 @@ defmodule ReuseChannelTest do
   use ExUnit.Case
   require Logger
 
-  # Code.require_file "client_runner.ex", __DIR__
-
-  # defmacro ae_url, do: Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  # defmacro network_id, do: Application.get_env(:ae_socket_connector, :node)[:network_id]
-
-  @ae_url Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  @network_id Application.get_env(:ae_socket_connector, :node)[:network_id]
-
   def clean_log_config_file(log_config) do
     File.rm(Path.join(log_config.path, log_config.file))
   end
@@ -109,8 +101,8 @@ defmodule ReuseChannelTest do
     clean_log_config_file(log_config_responder)
 
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SocketConnectorHelper.ae_url(),
+      SockerConnectorHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: SocketConnectorTest.accounts_initiator(), log_config: %{file: "consecutive_initiator", path: "data"}},
         responder: %{name: bob, keypair: SocketConnectorTest.accounts_responder(), log_config: %{file: "consecutive_responder", path: "data"}}
@@ -154,8 +146,8 @@ defmodule ReuseChannelTest do
     end
 
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SocketConnectorHelper.ae_url(),
+      SockerConnectorHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: SocketConnectorTest.accounts_initiator(), log_config: %{file: "consecutive_initiator", path: "data"}},
         responder: %{name: bob, keypair: SocketConnectorTest.accounts_responder(), log_config: %{file: "consecutive_responder", path: "data"}}

--- a/apps/ae_socket_connector/test/single_end_channel_test.exs
+++ b/apps/ae_socket_connector/test/single_end_channel_test.exs
@@ -1,10 +1,6 @@
 defmodule SingleEndChannelTest do
   use ExUnit.Case
   require Logger
-
-  @ae_url Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  @network_id Application.get_env(:ae_socket_connector, :node)[:network_id]
-
   def clean_log_config_file(log_config) do
     File.rm(Path.join(log_config.log, log_config.log))
   end
@@ -55,8 +51,8 @@ defmodule SingleEndChannelTest do
       })
 
     ClientRunner.start_peers(
-      @ae_url,
-      @network_id,
+      SocketConnectorHelper.ae_url(),
+      SockerConnectorHelper.network_id(),
       %{
         initiator: %{
           name: alice,


### PR DESCRIPTION
This code is dependent on https://github.com/aeternity/aeternity/issues/3169
Protocol updates https://github.com/aeternity/protocol/pull/470

Initiator can now leave and reestablish early as soon as channel_id is populated. More below.

This branch is the natural continuation for backend_service
* Channel_id (and fsm_id) is now picked up at `"funding_signed"` and "funding_created"` 
* Channel_id is populated automatically in the phoenix interface, allowing leave/reestablish without manually editing fields.
* Backend now supervises all channels
* Removed initiator and round when not available (channels_info and on_chain)
* Contact is automatically deployed at ":channels_info, round 1" 
* It's now ok to hit start backend channel multiple times (well only relevant after the channel id is present)
Closes #57 and closes #19 