### PR TITLE
Endpoint naming

### DIFF
--- a/apps/ae_channel_interface/README.md
+++ b/apps/ae_channel_interface/README.md
@@ -17,8 +17,9 @@ The backend logic operates according to rules specifed in the backed session whi
 - Point your browser to [http://localhost:4000/](http://localhost:4000/)
 - Click 'start backend channel' 
 > the backend now spawns the _responder_. The responder now waits for the initiator to connect
-> effecitvely a `get` request is shot at the backend in the url form of http://127.0.0.1:4000/connect/new?client_account=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610. The response is going to contain the assumed channel parameters for your convenience.
-- Click `connect websocket for initiator` 
+
+> effecitvely a `get` request is shot at the backend in the url form of http://127.0.0.1:4000/connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610 which is shown in `start backend channel` field. You can shoot of the same `get` from you js or app to start the responder. The `get` returns the parameters you need to provide from you client. Click the [link](http://127.0.0.1:4000/connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610) to try it your webbrowser. Check the response.
+- Click `connect websocket for initiator`
 > you have specified that your browser window represents the _initiator_
 - Click `connect`
 > messages should start arriving, you will shortly recieve a sign request 

--- a/apps/ae_channel_interface/assets/js/app.js
+++ b/apps/ae_channel_interface/assets/js/app.js
@@ -76,7 +76,7 @@ function encodeQueryData(data) {
 }
 
 function updateBackendParams(port, channel_id, public_account) {
-    backend_params.value = encodeQueryData({ port: port, channel_id, channel_id, client_account: public_account })
+    backend_params.value = encodeQueryData({ port: port, existing_channel_id: channel_id, initiator_id: public_account })
 }
 
 connect_port.addEventListener('input', function (updatevalue) {

--- a/apps/ae_channel_interface/assets/js/app.js
+++ b/apps/ae_channel_interface/assets/js/app.js
@@ -75,16 +75,21 @@ function encodeQueryData(data) {
     return ret.join('&');
 }
 
-function updateBackendParams(port, channel_id, public_account) {
-    backend_params.value = encodeQueryData({ port: port, existing_channel_id: channel_id, initiator_id: public_account })
+function updateBackendParams(host, port, channel_id, public_account) {
+    var params = encodeQueryData({ port: port, existing_channel_id: channel_id, initiator_id: public_account })
+    backend_params.value = backend_url.value.concat("?", params)
 }
 
+backend_url.addEventListener('input', function (updatevalue) {
+    updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
+});
+
 connect_port.addEventListener('input', function (updatevalue) {
-    updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+    updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
 });
 
 channel_id.addEventListener('change', function (updatevalue) {
-    updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+    updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
 });
 
 channel_id.addEventListener('input', function (updatevalue) {
@@ -93,11 +98,11 @@ channel_id.addEventListener('input', function (updatevalue) {
     } else {
         connect_btn.textContent = "Reestablish"
     }
-    updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+    updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
 });
 
 public_key.addEventListener('input', function (updatevalue) {
-    updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+    updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
 });
 
 function httpGet(theUrl) {
@@ -112,7 +117,7 @@ function httpGet(theUrl) {
 }
 
 start_backend_btn.addEventListener('click', function (event) {
-    console.log(httpGet(backend_url.value.concat("?", backend_params.value)))
+    console.log(httpGet(backend_params.value))
 });
 
 sign_btn.addEventListener('click', function (event) {
@@ -241,5 +246,5 @@ connect_responder_websocket_btn.addEventListener('click', function (event) {
     });
 });
 
-updateBackendParams(connect_port.value, channel_id.value, public_key.value)
+updateBackendParams(backend_url.value, connect_port.value, channel_id.value, public_key.value)
 connect_btn.disabled = true

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/user_controller.ex
@@ -58,10 +58,7 @@ defmodule AeChannelInterfaceWeb.ConnectController do
       initiator_id: initiator_id,
       api_endpoint: "connect/new",
       client: params,
-      expected_initiator_configuration: %{
-        basic: Map.from_struct(basic_params.basic_configuration),
-        custom: custom_params
-      }
+      expected_initiator_configuration: Map.merge(Map.from_struct(basic_params.basic_configuration), custom_params)
     })
   end
 

--- a/apps/ae_channel_interface/test/channel_interface_web/controllers/page_controller_test.exs
+++ b/apps/ae_channel_interface/test/channel_interface_web/controllers/page_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule AeChannelInterfaceWeb.PageControllerTest do
   use AeChannelInterfaceWeb.ConnCase
 
+  @tag :web
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "Welcome to Phoenix!"

--- a/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
+++ b/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
@@ -6,7 +6,7 @@ defmodule AeChannelInterfaceWeb.UserControllerTest do
     conn = get(conn, "connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610")
 
     assert conn.resp_body ==
-             "{\"api_endpoint\":\"connect/new\",\"client\":{\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"expected_initiator_configuration\":{\"channel_reserve\":\"2\",\"host\":\"localhost\",\"initiator_amount\":7000000000000,\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"lock_period\":\"10\",\"minimum_depth\":0,\"port\":1610,\"protocol\":\"json-rpc\",\"push_amount\":\"1\",\"responder_amount\":4000000000000,\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\",\"role\":\"initiator\"},\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
+             "{\"api_endpoint\":\"connect/new\",\"client\":{\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"expected_initiator_configuration\":{\"channel_reserve\":\"2\",\"host\":\"localhost\",\"initiator_amount\":7000000000000,\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"lock_period\":\"10\",\"minimum_depth\":0,\"port\":\"1610\",\"protocol\":\"json-rpc\",\"push_amount\":\"1\",\"responder_amount\":4000000000000,\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\",\"role\":\"initiator\"},\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
   end
 
   @tag :web

--- a/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
+++ b/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
@@ -6,7 +6,7 @@ defmodule AeChannelInterfaceWeb.UserControllerTest do
     conn = get(conn, "connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610")
 
     assert conn.resp_body ==
-             "{\"api_endpoint\":\"connect/new\",\"client\":{\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"expected_initiator_configuration\":{\"basic\":{\"initiator_amount\":7000000000000,\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_amount\":4000000000000,\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"},\"custom\":{\"channel_reserve\":\"2\",\"host\":\"localhost\",\"lock_period\":\"10\",\"minimum_depth\":0,\"port\":1610,\"protocol\":\"json-rpc\",\"push_amount\":\"1\",\"role\":\"initiator\"}},\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
+             "{\"api_endpoint\":\"connect/new\",\"client\":{\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"expected_initiator_configuration\":{\"channel_reserve\":\"2\",\"host\":\"localhost\",\"initiator_amount\":7000000000000,\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"lock_period\":\"10\",\"minimum_depth\":0,\"port\":1610,\"protocol\":\"json-rpc\",\"push_amount\":\"1\",\"responder_amount\":4000000000000,\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\",\"role\":\"initiator\"},\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
   end
 
   @tag :web

--- a/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
+++ b/apps/ae_channel_interface/test/channel_interface_web/controllers/user_controller_test.exs
@@ -1,0 +1,23 @@
+defmodule AeChannelInterfaceWeb.UserControllerTest do
+  use AeChannelInterfaceWeb.ConnCase
+
+  @tag :web
+  test "start backend service /new", %{conn: conn} do
+    conn = get(conn, "connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610")
+
+    assert conn.resp_body ==
+             "{\"api_endpoint\":\"connect/new\",\"client\":{\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"expected_initiator_configuration\":{\"basic\":{\"initiator_amount\":7000000000000,\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_amount\":4000000000000,\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"},\"custom\":{\"channel_reserve\":\"2\",\"host\":\"localhost\",\"lock_period\":\"10\",\"minimum_depth\":0,\"port\":1610,\"protocol\":\"json-rpc\",\"push_amount\":\"1\",\"role\":\"initiator\"}},\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
+  end
+
+  @tag :web
+  test "start backend service /new with reestablish", %{conn: conn} do
+    conn =
+      get(
+        conn,
+        "connect/new?initiator_id=ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh&port=1610&existing_channel_id=ch_wcNH5tcXDLbpCQpUwzusT4rbzJyF5ukbSKw5TatYe9Y1RwyM4"
+      )
+
+    assert conn.resp_body ==
+             "{\"api_endpoint\":\"connect/new\",\"client\":{\"existing_channel_id\":\"ch_wcNH5tcXDLbpCQpUwzusT4rbzJyF5ukbSKw5TatYe9Y1RwyM4\",\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"port\":\"1610\"},\"existing_channel_id\":\"ch_wcNH5tcXDLbpCQpUwzusT4rbzJyF5ukbSKw5TatYe9Y1RwyM4\",\"initiator_id\":\"ak_SVQ9RvinB2E8pio2kxtZqhRDwHEsmDAdQCQUhQHki5QyPxtMh\",\"responder_id\":\"ak_cFBreUSVWPEc3qSCYHfcy5yW2CWkbdrPkr9itgQfBw1Zdd6HV\"}"
+  end
+end


### PR DESCRIPTION
Use the same naming for configuration naming as in the fsm manual.

Backend and phoenix now allows so that client can pick it's own configuration. Updated documentation accordingly.

the get request return the default params if not provided.