### PR TITLE
Introducing backend active channels page

### DIFF
--- a/apps/ae_backend_service/lib/backend_service_manager.ex
+++ b/apps/ae_backend_service/lib/backend_service_manager.ex
@@ -33,6 +33,10 @@ defmodule BackendServiceManager do
     GenServer.call(pid, {:get_channel_id, identifier})
   end
 
+  def get_channel_table() do
+    GenServer.call(__MODULE__, :get_channel_table)
+  end
+
   def set_channel_id(pid, identifier, channel_id) do
     GenServer.call(pid, {:set_channel_id, identifier, channel_id})
   end
@@ -95,7 +99,7 @@ defmodule BackendServiceManager do
   end
 
   def handle_call({:set_channel_id, identifier, reestablish}, from, state) do
-    Logger.info("Channel poulated with channel_id #{inspect({identifier, reestablish})}")
+    Logger.info("Channel populated with channel_id #{inspect({identifier, reestablish})}")
 
     {:reply, :ok,
      %__MODULE__{state | channel_id_table: Map.put(state.channel_id_table, identifier, {reestablish, from})}}
@@ -133,5 +137,9 @@ defmodule BackendServiceManager do
         Process.monitor(pid)
         {:reply, {:ok, pid}, state}
     end
+  end
+
+  def handle_call(:get_channel_table, _from, state) do
+    {:reply, {:ok, state.channel_id_table}, state}
   end
 end

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -99,7 +99,7 @@ defmodule BackendSession do
   # if we don't update the channel id somewhere here,
   # channel_id will be known as nil by BackendServiceManager
   def handle_cast({:channels_info, method, channel_id}, state)
-      when method in ["funding_signed", "funding_created", "open"] do
+      when method in ["funding_signed", "funding_created"] do
     BackendServiceManager.set_channel_id(state.pid_backend_manager, state.identifier, {channel_id, state.port})
     {:noreply, state}
   end

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -96,8 +96,10 @@ defmodule BackendSession do
   end
 
   # once this occured we should be able to reconnect.
+  # if we don't update the channel id somewhere here,
+  # channel_id will be known as nil by BackendServiceManager
   def handle_cast({:channels_info, method, channel_id}, state)
-      when method in ["funding_signed", "funding_created"] do
+      when method in ["funding_signed", "funding_created", "open"] do
     BackendServiceManager.set_channel_id(state.pid_backend_manager, state.identifier, {channel_id, state.port})
     {:noreply, state}
   end

--- a/apps/ae_channel_interface/README.md
+++ b/apps/ae_channel_interface/README.md
@@ -28,6 +28,8 @@ The backend logic operates according to rules specifed in the backed session whi
 > the same goes for `channel_id` which identifies the channel. `channel_id` must be provided to reestablish a lost connection. 
 > you need to wait for minimum confirmation time. Have patience (minutes), eventually you should see an `open` message
  
+(Optional) Now, you can go and visit [http://localhost:4000/channels](http://localhost:4000/channels)
+which will list all currently active channels for channel backend service.
 
 ### Suggested approach 2 (manual initiator, manual backend)
 In this example you control both the initator and the responder

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/page_controller.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/page_controller.ex
@@ -4,4 +4,10 @@ defmodule AeChannelInterfaceWeb.PageController do
   def index(conn, _params) do
     render(conn, "index.html")
   end
+
+  def show(conn, _params) do
+    {:ok, channels_list} = BackendServiceManager.get_channel_table()
+    active_channels = Enum.map(channels_list, fn {k, {{channel_id, _num}, _}} -> {k, channel_id} end)
+    render(conn, "show.html", active_channels: active_channels)
+  end
 end

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/router.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/router.ex
@@ -17,6 +17,7 @@ defmodule AeChannelInterfaceWeb.Router do
     pipe_through(:browser)
 
     get("/", PageController, :index)
+    get("/channels", PageController, :show)
     resources("/connect", ConnectController, only: [:new])
   end
 

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/layout/app.html.eex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/layout/app.html.eex
@@ -11,8 +11,10 @@
     <header>
       <section class="container">
         <nav role="navigation">
-          <ul>
-            <li><a href="https://aeternity.com/documentation-hub/">Get Started</a></li>
+          <ul "display: flex, flex-direction: row">
+            <li style="text-align: left"><a href="https://aeternity.com/documentation-hub/">Get Started</a></li>
+            <li style="text-align: left"><a href="<%= Routes.page_path(@conn, :index)%>">Back to Channels Interface </a></li>
+            <li style="text-align: left"><a href="<%= Routes.page_path(@conn, :show)%>">Backend: Currently active channels</a></li>
           </ul>
         </nav>
         <a href="https://aeternity.com/" class="phx-logo">

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/page/show.html.eex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/page/show.html.eex
@@ -1,0 +1,16 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">ID </th>
+      <th scope="col">Channel id</th>
+    </tr>
+  </thead>
+  <tbody>
+ <%= for {id,channel_id} <- @active_channels do %>
+   <tr>
+     <th scope="row"><%= id %></th>
+     <td><%= channel_id %></td>
+   </tr>
+ <% end %>
+  </tbody>
+ </table>


### PR DESCRIPTION
Partially Resolves #68 
This PR includes new page, which is available at `/channels`, which renders currently active channels.