### PR TITLE
Backend custom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Point your browser to [http://localhost:4000/](http://localhost:4000/). Each tab
 AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
 ```
 
+More detailed when needed
+```bash
+TOSS_MODE="random|tails|heads" GAME_MODE="fair|malicious" FORCE_PROGRESS_HEIGHT="15|any_positive_integer" AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
+```
+> defaults are listed as first available option
+
 Point your browser to [http://localhost:4000/](http://localhost:4000/). Each tab can represent a peer. _Initiator_ or _responder_. "Backend helper" starts a channel governed by the [ae_backend_service](apps/ae_backend_service/lib/backend_session.ex) and does not affect the tab.
 > testnet is currently load balanced, you need to be persistent (try again) to get your channel up and running. Current recomended worksround is to host your own node.
 

--- a/apps/ae_backend_service/config/config.exs
+++ b/apps/ae_backend_service/config/config.exs
@@ -8,6 +8,11 @@ use Mix.Config
 # if you want to provide default values for your application for
 # third-party users, it should be done in your "mix.exs" file.
 
+config :ae_backend_service, :game,
+  toss_mode: System.get_env("TOSS_MODE") || "random",
+  game_mode: System.get_env("GAME_MODE") || "fair",
+  force_progress_height: System.get_env("FORCE_PROGRESS_HEIGHT") || "15"
+
 # You can configure your application as:
 #
 #     config :ae_backend_service, key: :value

--- a/apps/ae_backend_service/lib/backend_session.ex
+++ b/apps/ae_backend_service/lib/backend_session.ex
@@ -18,7 +18,7 @@ defmodule BackendSession do
             identifier: nil,
             params: nil,
             port: nil,
-            channel_config: nil,
+            channel_params: nil,
             game: %{},
             responder_contract: nil,
             expected_state: nil
@@ -62,14 +62,17 @@ defmodule BackendSession do
       {TestAccounts.responderPubkeyEncoded(), "contracts/coin_toss.aes",
        %{abi_version: 3, vm_version: 5, backend: :fate}}
 
-    Logger.error("Channel_config is #{inspect(channel_config)}")
+    {initiator_id, _initiator_priv_key} = initiator_keypair.()
+    {responder_id, _repsonder_priv_key} = keypair_responder()
+
+    channel_params = channel_config.(initiator_id, responder_id).custom_param_fun.(:responder, "irrelevant")
 
     {:noreply,
      %__MODULE__{
        state
        | pid_session_holder: pid,
          port: port,
-         channel_config: channel_config,
+         channel_params: channel_params,
          responder_contract: responder_contract
      }}
   end
@@ -210,8 +213,9 @@ defmodule BackendSession do
     # check whether there is coverage enough in the channel, if not abort.
     fun = &SocketConnector.query_funds(&1, &2)
     funds = SessionHolder.run_action_sync(state.pid_session_holder, fun)
-    # TODO this check need to take channel_reserve into account.
-    fund_check = for %{"balance" => balance} = entry <- funds, balance >= amount, do: entry
+
+    {channel_reserve, ""} = Integer.parse(state.channel_params[:channel_reserve])
+    fund_check = for %{"balance" => balance} = entry <- funds, balance - channel_reserve >= amount, do: entry
 
     case Enum.count(fund_check) == 2 do
       true ->

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/channels/socket_connector_channel.ex
@@ -55,7 +55,7 @@ defmodule AeChannelInterfaceWeb.SocketConnectorChannel do
   def handle_in(action, payload, socket) do
     socketholder_pid = socket.assigns.pid_session_holder
 
-    Logger.error("Called action #{inspect({action, payload})}")
+    Logger.info("Called action #{inspect({action, payload})}")
 
     case action do
       "leave" ->

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -1006,19 +1006,6 @@ defmodule SocketConnector do
     {:ok, state}
   end
 
-  @self [
-    "channels.sign.update",
-    "channels.sign.initiator_sign",
-    "channels.sign.deposit_tx",
-    "channels.sign.withdraw_tx"
-  ]
-  @other [
-    "channels.sign.update_ack",
-    "channels.sign.responder_sign",
-    "channels.sign.deposit_ack",
-    "channels.sign.withdraw_ack"
-  ]
-
   # @spec decode_calldata(any, any) :: :empty | :ok | {:error, any}
   def decode_calldata(updates, state) do
     entries =
@@ -1052,6 +1039,19 @@ defmodule SocketConnector do
         end
     end
   end
+
+  @self [
+    "channels.sign.update",
+    "channels.sign.initiator_sign",
+    "channels.sign.deposit_tx",
+    "channels.sign.withdraw_tx"
+  ]
+  @other [
+    "channels.sign.update_ack",
+    "channels.sign.responder_sign",
+    "channels.sign.deposit_ack",
+    "channels.sign.withdraw_ack"
+  ]
 
   def process_message(
         %{


### PR DESCRIPTION
resolves #95 

- Also fixes issue where channel reserve isn't respected when checking if funds are enough for a toss.

Following options are now avaliable
```bash
TOSS_MODE="random|tails|heads" GAME_MODE="fair|malicious" FORCE_PROGRESS_HEIGHT="15|any_positive_integer" AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
```