### PR TITLE
Backend active channels page improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ Point your browser to [http://localhost:4000/](http://localhost:4000/). Each tab
 ## Run sample interactive web client (testnet)
 
 ```bash
-AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
+AE_NODE_URL_WS="wss://testnet.aeternity.io:443/channel" AE_NODE_URL_HTTP="testnet.aeternity.io" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
 ```
 
 More detailed when needed
 ```bash
-TOSS_MODE="random|tails|heads" GAME_MODE="fair|malicious" FORCE_PROGRESS_HEIGHT="15|any_positive_integer" AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
+TOSS_MODE="random|tails|heads" GAME_MODE="fair|malicious" FORCE_PROGRESS_HEIGHT="15|any_positive_integer" AE_NODE_URL_WS="wss://testnet.aeternity.io:443/channel"  AE_NODE_URL_HTTP="http://localhost:3013/"
+AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
 ```
 > defaults are listed as first available option
 
@@ -65,7 +66,7 @@ mix test
 
 or for testnet
 ```bash
-AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" mix test
+AE_NODE_URL_WS="wss://testnet.aeternity.io:443/channel" AE_NODE_URL_HTTP="http://testnet.aeternity.io" AE_NODE_NETWORK_ID="ae_uat" mix test
 ```
 
 Scenarios executed can be found [here](apps/ae_socket_connector/test/ae_socket_connector_test.exs)

--- a/apps/ae_backend_service/README.md
+++ b/apps/ae_backend_service/README.md
@@ -31,5 +31,5 @@ In order to test specific scenarios the backend behaviour can be configured with
 ```bash
 TOSS_MODE="random|tails|heads" GAME_MODE="fair|malicious" FORCE_PROGRESS_HEIGHT="15|any_positive_integer" 
 MINE_RATE="180000|any_positive_integer"
-AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
+AE_NODE_URL="wss://testnet.aeternity.io:443/channel" AE_NODE_URL_HTTP="http://testnet.aeternity.io" AE_NODE_NETWORK_ID="ae_uat" iex -S mix phx.server
 ```

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/page_controller.ex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/controllers/page_controller.ex
@@ -1,13 +1,29 @@
 defmodule AeChannelInterfaceWeb.PageController do
   use AeChannelInterfaceWeb, :controller
 
+  alias ChannelService.OnChain
+
   def index(conn, _params) do
     render(conn, "index.html")
   end
 
   def show(conn, _params) do
     {:ok, channels_list} = BackendServiceManager.get_channel_table()
-    active_channels = Enum.map(channels_list, fn {k, {{channel_id, _num}, _}} -> {k, channel_id} end)
-    render(conn, "show.html", active_channels: active_channels)
+
+    channels_with_info =
+      Enum.map(channels_list, fn {id, {actual_channel_id, _}} -> get_channel_info(actual_channel_id) end)
+
+    conn
+    |> assign(:channels, channels_with_info)
+    |> render("show.html")
+  end
+
+  defp get_channel_info({<<"ch_", _::binary>> = channel_id, _}) do
+    channel_id
+    |> OnChain.get_channel_info(SessionHolderHelper.ae_url_http())
+  end
+
+  defp get_channel_info(channel_id) do
+    []
   end
 end

--- a/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/page/show.html.eex
+++ b/apps/ae_channel_interface/lib/ae_channel_interface_web/templates/page/show.html.eex
@@ -1,16 +1,50 @@
-<table class="table">
+<html>
+<head>
+<style>
+table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  border-collapse: collapse;
+}
+</style>
+</head>
+<table >
   <thead>
     <tr>
-      <th scope="col">ID </th>
-      <th scope="col">Channel id</th>
+      <th scope="col">Channel ID</th>
+      <th scope="col">Amount</th>
+      <th scope="col">Reserve</th>
+      <th scope="col">Delegate IDs</th>
+      <th scope="col">Initiator amount</th>
+      <th scope="col">Initiator ID</th>
+      <th scope="col">Lock period</th>
+      <th scope="col">Locked until</th>
+      <th scope="col">Responder amount</th>
+      <th scope="col">Responder ID</th>
+      <th scope="col">Round</th>
+      <th scope="col">Solo round</th>
+      <th scope="col">State hash</th>
     </tr>
   </thead>
   <tbody>
- <%= for {id,channel_id} <- @active_channels do %>
+ <%= for channel <- @conn.assigns[:channels] do %>
    <tr>
-     <th scope="row"><%= id %></th>
-     <td><%= channel_id %></td>
+     <th scope="row"><%= channel["id"] %></th>
+     <td><%= channel["channel_amount"] %></td>
+     <td><%= channel["channel_reserve"] %></td>
+     <td><%= channel["delegate_ids"] %> </td>
+     <td><%= channel["initiator_amount"] %></td>
+     <td><%= channel["initiator_id"] %></td>
+     <td><%= channel["lock_period"] %></td>
+     <td><%= channel["locked_until"] %></td>
+     <td><%= channel["responder_amount"] %></td>
+     <td><%= channel["responder_id"] %></td>
+     <td><%= channel["round"] %></td>
+     <td><%= channel["solo_round"] %></td>
+     <td><%= channel["state_hash"] %></td>
    </tr>
  <% end %>
   </tbody>
  </table>
+ </html>

--- a/apps/ae_socket_connector/config/config.exs
+++ b/apps/ae_socket_connector/config/config.exs
@@ -6,7 +6,8 @@ config :logger,
   ]
 
 config :ae_socket_connector, :node,
-  ae_url: System.get_env("AE_NODE_URL") || "ws://localhost:3014/channel",
+  ae_url_ws: System.get_env("AE_NODE_URL_WS") || "ws://localhost:3014/channel",
+  ae_url_http: System.get_env("AE_NODE_URL_HTTP") || "http://localhost:3013/",
   network_id: System.get_env("AE_NODE_NETWORK_ID") || "my_test",
   deps_path: "aeternity/lib"
 

--- a/apps/ae_socket_connector/lib/on_chain.ex
+++ b/apps/ae_socket_connector/lib/on_chain.ex
@@ -35,4 +35,9 @@ defmodule ChannelService.OnChain do
     %{"tx_hash" => tx_hash} = Poison.decode!(HTTPotion.post(url, body: body, headers: header).body)
     Logger.debug("track transaction curl http://localhost:3013/v2/transactions/" <> tx_hash)
   end
+
+  def get_channel_info(<<"ch_", _rest::binary>> = channel_id, node_url) do
+    url = build_url(node_url, "/v2/channels/#{channel_id}")
+    Poison.decode!(HTTPotion.get(url).body)
+  end
 end

--- a/apps/ae_socket_connector/lib/session_holder_helper.ex
+++ b/apps/ae_socket_connector/lib/session_holder_helper.ex
@@ -1,7 +1,6 @@
 defmodule SessionHolderHelper do
-  def ae_url() do
-    Application.get_env(:ae_socket_connector, :node)[:ae_url]
-  end
+  def ae_url_ws(), do: Application.get_env(:ae_socket_connector, :node)[:ae_url_ws]
+  def ae_url_http(), do: Application.get_env(:ae_socket_connector, :node)[:ae_url_http]
 
   def network_id() do
     Application.get_env(:ae_socket_connector, :node)[:network_id]
@@ -194,7 +193,7 @@ defmodule SessionHolderHelper do
         role: role
       },
       log_config: generate_log_config(role, pub_key, "data"),
-      ae_url: ae_url(),
+      ae_url: ae_url_ws(),
       network_id: network_id(),
       priv_key: priv_key,
       connection_callbacks: connection_callback_handler,

--- a/apps/ae_socket_connector/lib/socket_connector.ex
+++ b/apps/ae_socket_connector/lib/socket_connector.ex
@@ -97,7 +97,7 @@ defmodule SocketConnector do
     session_map = init_map(session, role, ws_base)
 
     ws_url = create_link(ws_base, session_map)
-    Logger.error("start_link #{inspect(ws_url)}", ansi_color: color)
+    Logger.info("start_link #{inspect(ws_url)}", ansi_color: color)
 
     {:ok, pid} =
       WebSockex.start_link(ws_url, __MODULE__, %__MODULE__{

--- a/apps/ae_socket_connector/test/ae_socket_connector_test.exs
+++ b/apps/ae_socket_connector/test/ae_socket_connector_test.exs
@@ -100,7 +100,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1400})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -140,7 +140,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1401})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -203,7 +203,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1402})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -238,13 +238,13 @@ defmodule SocketConnectorTest do
            next:
              {:local,
               fn client_runner, pid_session_holder ->
-                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url(), intiator_account)
-                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url())
+                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url_ws(), intiator_account)
+                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url_ws())
                 Logger.debug("nonce is #{inspect(nonce)} height is: #{inspect(height)}")
 
                 transaction = SessionHolder.solo_close_transaction(pid_session_holder, 2, nonce + 1, height)
 
-                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url(), transaction)
+                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url_ws(), transaction)
                 ClientRunnerHelper.resume_runner(client_runner)
               end, :empty}
          }},
@@ -266,7 +266,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1403})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -312,8 +312,8 @@ defmodule SocketConnectorTest do
            next:
              {:local,
               fn client_runner, pid_session_holder ->
-                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url(), intiator_account)
-                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url())
+                nonce = ChannelService.OnChain.nonce(SessionHolderHelper.ae_url_ws(), intiator_account)
+                height = ChannelService.OnChain.current_height(SessionHolderHelper.ae_url_ws())
 
                 transaction =
                   GenServer.call(
@@ -321,7 +321,7 @@ defmodule SocketConnectorTest do
                     {:solo_close_transaction, 2, nonce + 1, height}
                   )
 
-                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url(), transaction)
+                ChannelService.OnChain.post_solo_close(SessionHolderHelper.ae_url_ws(), transaction)
                 ClientRunnerHelper.resume_runner(client_runner)
               end, :empty}
          }},
@@ -363,7 +363,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1404})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -435,7 +435,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1405})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -570,7 +570,7 @@ defmodule SocketConnectorTest do
     end
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
@@ -628,7 +628,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1406})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -682,7 +682,7 @@ defmodule SocketConnectorTest do
     end
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
@@ -779,7 +779,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1407})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -1050,7 +1050,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -1166,7 +1166,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -1343,7 +1343,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},
@@ -1452,7 +1452,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 0, port: 1408})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator()},
@@ -1535,7 +1535,7 @@ defmodule SocketConnectorTest do
     channel_config = SessionHolderHelper.custom_config(%{}, %{minimum_depth: 50, port: 1409})
 
     ClientRunner.start_peers(
-      SessionHolderHelper.ae_url(),
+      SessionHolderHelper.ae_url_ws(),
       SessionHolderHelper.network_id(),
       %{
         initiator: %{name: alice, keypair: accounts_initiator(), custom_configuration: channel_config},

--- a/apps/ae_socket_connector/test/reuse_channel_test.exs
+++ b/apps/ae_socket_connector/test/reuse_channel_test.exs
@@ -101,7 +101,7 @@ defmodule ReuseChannelTest do
     clean_log_config_file(log_config_responder)
 
     ClientRunner.start_peers(
-      SocketConnectorHelper.ae_url(),
+      SocketConnectorHelper.ae_url_ws(),
       SockerConnectorHelper.network_id(),
       %{
         initiator: %{
@@ -154,7 +154,7 @@ defmodule ReuseChannelTest do
     end
 
     ClientRunner.start_peers(
-      SocketConnectorHelper.ae_url(),
+      SocketConnectorHelper.ae_url_ws(),
       SockerConnectorHelper.network_id(),
       %{
         initiator: %{

--- a/apps/ae_socket_connector/test/single_end_channel_test.exs
+++ b/apps/ae_socket_connector/test/single_end_channel_test.exs
@@ -52,8 +52,8 @@ defmodule SingleEndChannelTest do
       })
 
     ClientRunner.start_peers(
-      SocketConnectorHelper.ae_url(),
-      SockerConnectorHelper.network_id(),
+      SessionHolderHelper.ae_url_ws(),
+      SessionHolderHelper.network_id(),
       %{
         initiator: %{
           name: alice,

--- a/test/aeternity_node_fast_test_config.yml
+++ b/test/aeternity_node_fast_test_config.yml
@@ -12,6 +12,9 @@ chain:
       "2": 1
       "3": 2
       "4": 3
+http:
+    external:
+        port: 3013
 mining:
     # Start mining automatically.
     autostart: true

--- a/test/aeternity_node_normal_test_config.yml
+++ b/test/aeternity_node_normal_test_config.yml
@@ -12,7 +12,9 @@ chain:
       "2": 1
       "3": 2
       "4": 3
-
+http:
+    external:
+        port: 3013
 mining:
     # Start mining automatically.
     autostart: true


### PR DESCRIPTION
This PR closes #81 , as well as it introduces miner's `HTTP` endpoint exposure(see changes in miner config), adding new configurable value, which is(and will probably be) needed for most `on-chain` data receiving. Backend active channels interface page now shows actual `on-chain` data for any known `channel id's` which are related to the given backend service.